### PR TITLE
Convert newlines when copying text from eco

### DIFF
--- a/lib/eco/treemanager.py
+++ b/lib/eco/treemanager.py
@@ -1142,7 +1142,10 @@ class TreeManager(object):
 
         text.append(start.symbol.name[diff_start:])
         for node in nodes:
-            text.append(node.symbol.name)
+            if node.lookup == "<return>":
+                text.append("\n")
+            else:
+                text.append(node.symbol.name)
         text.append(end.symbol.name[:diff_end])
         return "".join(text)
 


### PR DESCRIPTION
Newlines in Eco are represented as `\r`. When copying text from within Eco and pasting it into another text editor (e.g. vim) the newlines are no recognized properly. This patch fixes it by converting copied text to `\n`.
