### PR TITLE
Profiler heatmap

### DIFF
--- a/lib/eco/eco.py
+++ b/lib/eco/eco.py
@@ -306,6 +306,12 @@ class SettingsView(QtGui.QMainWindow):
         size = settings.value("font-size").toInt()[0]
         self.ui.app_fontfamily.setCurrentFont(QtGui.QFont(family, size))
         self.ui.app_fontsize.setValue(size)
+
+        tool_info_family = settings.value("tool-font-family").toString()
+        tool_info_size = settings.value("tool-font-size").toInt()[0]
+        self.ui.tool_info_fontfamily.setCurrentFont(QtGui.QFont(tool_info_family, tool_info_size))
+        self.ui.tool_info_fontsize.setValue(size)
+
         self.ui.app_theme.setCurrentIndex(settings.value("app_themeindex", 0).toInt()[0])
         self.ui.app_custom.setChecked(settings.value("app_custom", False).toBool())
         self.foreground = settings.value("app_foreground", "#000000").toString()
@@ -320,6 +326,10 @@ class SettingsView(QtGui.QMainWindow):
 
         settings.setValue("font-family", self.ui.app_fontfamily.currentFont().family())
         settings.setValue("font-size", self.ui.app_fontsize.value())
+
+        settings.setValue("tool-font-family", self.ui.tool_info_fontfamily.currentFont().family())
+        settings.setValue("tool-font-size", self.ui.tool_info_fontsize.value())
+
         settings.setValue("app_theme", self.ui.app_theme.currentText())
         settings.setValue("app_themeindex", self.ui.app_theme.currentIndex())
         settings.setValue("app_custom", self.ui.app_custom.isChecked())
@@ -331,6 +341,8 @@ class SettingsView(QtGui.QMainWindow):
         settings = QSettings("softdev", "Eco")
         gfont = QApplication.instance().gfont
         gfont.setfont(QFont(settings.value("font-family").toString(), settings.value("font-size").toInt()[0]))
+        tool_info_font = QApplication.instance().tool_info_font
+        tool_info_font.setfont(QFont(settings.value("tool-font-family").toString(), settings.value("tool-font-size").toInt()[0]))
         self.window.refreshTheme()
         self.close()
 
@@ -1071,8 +1083,12 @@ def main():
     if not settings.contains("font-family"):
         settings.setValue("font-family", "Monospace")
         settings.setValue("font-size", 9)
+    if not settings.contains("tool-font-family"):
+        settings.setValue("tool-font-family", "Monospace")
+        settings.setValue("tool-font-size", 9)
 
     app.gfont = GlobalFont(settings.value("font-family").toString(), settings.value("font-size").toInt()[0])
+    app.tool_info_font = GlobalFont(settings.value("tool-font-family").toString(), settings.value("tool-font-size").toInt()[0])
     app.showindent = False
 
     window=Window()

--- a/lib/eco/eco.py
+++ b/lib/eco/eco.py
@@ -980,6 +980,11 @@ class Window(QtGui.QMainWindow):
             self.ui.tabWidget.removeTab(index)
 
     def tabChanged(self, index):
+        ed_tab = self.getEditorTab()
+        if (ed_tab is not None) and ed_tab.editor.is_overlay_visible():
+            self.ui.actionShow_tool_visualisations.setChecked(True)
+        else:
+            self.ui.actionShow_tool_visualisations.setChecked(False)
         self.btReparse()
 
     def closeEvent(self, event):

--- a/lib/eco/gui/gui.ui
+++ b/lib/eco/gui/gui.ui
@@ -71,6 +71,7 @@
     </property>
     <addaction name="actionRun"/>
     <addaction name="actionProfile"/>
+    <addaction name="actionVisualise_automatically"/>
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
@@ -549,6 +550,14 @@
    </property>
    <property name="text">
     <string>Show tool visualisations</string>
+   </property>
+  </action>
+  <action name="actionVisualise_automatically">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Visualise automatically</string>
    </property>
   </action>
  </widget>

--- a/lib/eco/gui/gui.ui
+++ b/lib/eco/gui/gui.ui
@@ -84,6 +84,7 @@
     <addaction name="actionShow_language_boxes"/>
     <addaction name="actionShow_namebinding"/>
     <addaction name="actionShow_indentation"/>
+    <addaction name="actionShow_tool_visualisations"/>
    </widget>
    <widget class="QMenu" name="menuInfo">
     <property name="title">
@@ -540,6 +541,14 @@
   <action name="actionProfile">
    <property name="text">
     <string>Profile</string>
+   </property>
+  </action>
+  <action name="actionShow_tool_visualisations">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show tool visualisations</string>
    </property>
   </action>
  </widget>

--- a/lib/eco/gui/settings.ui
+++ b/lib/eco/gui/settings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>378</width>
-    <height>412</height>
+    <height>536</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -62,7 +62,7 @@
        <attribute name="title">
         <string>Appearance</string>
        </attribute>
-       <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,1">
+       <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,1">
         <property name="sizeConstraint">
          <enum>QLayout::SetDefaultConstraint</enum>
         </property>
@@ -76,6 +76,9 @@
             <widget class="QLabel" name="label_3">
              <property name="text">
               <string>Family</string>
+             </property>
+             <property name="buddy">
+              <cstring>app_fontfamily</cstring>
              </property>
             </widget>
            </item>
@@ -93,6 +96,48 @@
             <widget class="QLabel" name="label_4">
              <property name="text">
               <string>Size</string>
+             </property>
+             <property name="buddy">
+              <cstring>app_fontsize</cstring>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="groupBox">
+          <property name="title">
+           <string>Font (profiler and tool information)</string>
+          </property>
+          <layout class="QFormLayout" name="formLayout_6">
+           <property name="fieldGrowthPolicy">
+            <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+           </property>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_7">
+             <property name="text">
+              <string>Size</string>
+             </property>
+             <property name="buddy">
+              <cstring>tool_info_fontsize</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QSpinBox" name="tool_info_fontsize"/>
+           </item>
+           <item row="1" column="1">
+            <widget class="QFontComboBox" name="tool_info_fontfamily">
+             <property name="fontFilters">
+              <set>QFontComboBox::MonospacedFonts</set>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_8">
+             <property name="text">
+              <string>Family</string>
              </property>
             </widget>
            </item>
@@ -159,6 +204,9 @@
              <property name="text">
               <string>Foreground:</string>
              </property>
+             <property name="buddy">
+              <cstring>app_foreground</cstring>
+             </property>
             </widget>
            </item>
            <item row="0" column="1">
@@ -178,6 +226,9 @@
             <widget class="QLabel" name="label_2">
              <property name="text">
               <string>Background:</string>
+             </property>
+             <property name="buddy">
+              <cstring>app_background</cstring>
              </property>
             </widget>
            </item>
@@ -213,7 +264,7 @@
      <x>0</x>
      <y>0</y>
      <width>378</width>
-     <height>27</height>
+     <height>26</height>
     </rect>
    </property>
   </widget>
@@ -221,4 +272,21 @@
  </widget>
  <resources/>
  <connections/>
+ <designerdata>
+  <property name="gridDeltaX">
+   <number>10</number>
+  </property>
+  <property name="gridDeltaY">
+   <number>10</number>
+  </property>
+  <property name="gridSnapX">
+   <bool>true</bool>
+  </property>
+  <property name="gridSnapY">
+   <bool>true</bool>
+  </property>
+  <property name="gridVisible">
+   <bool>true</bool>
+  </property>
+ </designerdata>
 </ui>

--- a/lib/eco/gui/settings.ui
+++ b/lib/eco/gui/settings.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>378</width>
-    <height>536</height>
+    <width>413</width>
+    <height>626</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -62,7 +62,7 @@
        <attribute name="title">
         <string>Appearance</string>
        </attribute>
-       <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,1">
+       <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,1,0">
         <property name="sizeConstraint">
          <enum>QLayout::SetDefaultConstraint</enum>
         </property>
@@ -138,6 +138,9 @@
             <widget class="QLabel" name="label_8">
              <property name="text">
               <string>Family</string>
+             </property>
+             <property name="buddy">
+              <cstring>tool_info_fontfamily</cstring>
              </property>
             </widget>
            </item>
@@ -245,6 +248,75 @@
           </layout>
          </widget>
         </item>
+        <item>
+         <widget class="QGroupBox" name="groupbox_5">
+          <property name="title">
+           <string>Heatmap gradient</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout">
+           <item row="1" column="1">
+            <widget class="QPushButton" name="heatmap_low">
+             <property name="styleSheet">
+              <string notr="true">background-color: rgb(255, 255, 255)</string>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QPushButton" name="heatmap_high">
+             <property name="autoFillBackground">
+              <bool>false</bool>
+             </property>
+             <property name="styleSheet">
+              <string notr="true">background-color:  rgb(72, 72, 72)</string>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_10">
+             <property name="text">
+              <string>Lowest value:</string>
+             </property>
+             <property name="buddy">
+              <cstring>heatmap_low</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_9">
+             <property name="text">
+              <string>Highest value:</string>
+             </property>
+             <property name="buddy">
+              <cstring>heatmap_high</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_11">
+             <property name="text">
+              <string>Transparency:</string>
+             </property>
+             <property name="buddy">
+              <cstring>heatmap_alpha</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QSpinBox" name="heatmap_alpha">
+             <property name="maximum">
+              <number>255</number>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
        </layout>
       </widget>
      </widget>
@@ -263,7 +335,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>378</width>
+     <width>413</width>
      <height>26</height>
     </rect>
    </property>

--- a/lib/eco/nodeeditor.py
+++ b/lib/eco/nodeeditor.py
@@ -81,6 +81,10 @@ class NodeEditor(QFrame):
         # Start hidden, make (in)visible with self.toggle_overlay().
         self.overlay.hide()
 
+        # Set True if Eco should be running profiler and other tools,
+        # continuously in the background.
+        self.run_background_tools = False
+
     def toggle_overlay(self):
         self.hide_overlay() if self.overlay.isVisible() else self.show_overlay()
 

--- a/lib/eco/nodeeditor.py
+++ b/lib/eco/nodeeditor.py
@@ -51,10 +51,6 @@ class NodeEditor(QFrame):
     def __init__(self, parent=None):
         QtGui.QWidget.__init__(self, parent)
 
-        self.infofont = QtGui.QFont('Courier', 9)
-        self.infofontht = QtGui.QFontMetrics(self.infofont).height() + 3
-        self.infofontwt = QtGui.QFontMetrics(self.infofont).width(" ")
-
         self.viewport_y = 0 # top visible line
         self.imagemode = False
         self.image = None
@@ -394,16 +390,18 @@ class NodeEditor(QFrame):
             self.lines[line].height = max(self.lines[line].height, dy)
 
             # Draw profiling information.
+            infofont = QApplication.instance().tool_info_font
+
             if node in self.tm.profile_map:
                 prof = self.tm.profile_map[node]
                 if not self.tm.profile_is_dirty:
-                    self.infofont.setBold(True)
+                    infofont.font.setBold(True)
                 else:
-                    self.infofont.setBold(False)
-                paint.setFont(self.infofont)
+                    infofont.font.setBold(False)
+                paint.setFont(infofont.font)
                 paint.setPen(QPen(QColor((highlighter.get_default_color()))))
-                start_x = (0 if (x - len(prof) * self.infofontwt) < 0
-                             else x - len(prof) * self.infofontwt)
+                start_x = (0 if (x - len(prof) * infofont.fontwt) < 0
+                             else x - len(prof) * infofont.fontwt)
                 start_y = self.fontht + ((y + 1) * self.fontht)
                 paint.drawText(QtCore.QPointF(x-dx, start_y), prof)
                 self.lines[line].height = max(self.lines[line].height, 2)
@@ -471,8 +469,8 @@ class NodeEditor(QFrame):
                 color = QColor(100,255,100)
             else:
                 color = QColor(255,100,100)
-            paint.setFont(self.infofont)
-            paint.fillRect(QRect(infobox_coordinates[0], 5 + infobox_coordinates[1], len(lang_name)*self.infofontwt, self.infofontht), color)
+            paint.setFont(infofont)
+            paint.fillRect(QRect(infobox_coordinates[0], 5 + infobox_coordinates[1], len(lang_name)*infofontwt, infofontht), color)
             paint.drawText(QtCore.QPointF(infobox_coordinates[0], -3 + self.fontht + infobox_coordinates[1]), lang_name)
             paint.setFont(self.font)
 

--- a/lib/eco/nodeeditor.py
+++ b/lib/eco/nodeeditor.py
@@ -35,6 +35,8 @@ from incparser.astree import TextNode, BOS, EOS, ImageNode, FinishSymbol
 from jsonmanager import JsonManager
 from astanalyser import AstAnalyser
 
+from overlay import Overlay
+
 import syntaxhighlighter
 import editor
 
@@ -76,6 +78,31 @@ class NodeEditor(QFrame):
         self.lightcolors = [QColor("#333333"), QColor("#859900"), QColor("#DC322F"), QColor("#268BD2"), QColor("#D33682"), QColor("#B58900"), QColor("#2AA198")]
         self.darkcolors = [QColor("#999999"), QColor("#859900"), QColor("#DC322F"), QColor("#268BD2"), QColor("#D33682"), QColor("#B58900"), QColor("#2AA198")]
         self.setCursor(Qt.IBeamCursor)
+
+        # Semi-transparent overlay.
+        # Used to display heat-map visualisation of profiler info, etc.
+        self.overlay = Overlay(self)
+        # Start hidden, make (in)visible with self.toggle_overlay().
+        self.overlay.hide()
+
+    def toggle_overlay(self):
+        self.hide_overlay() if self.overlay.isVisible() else self.show_overlay()
+
+    def show_overlay(self):
+        self.overlay.show()
+
+    def hide_overlay(self):
+        self.overlay.hide()
+
+    def set_tool_data(self, tool_data):
+        """Receive data form a profiler or tool, visualise and display.
+        """
+        self.overlay.data = tool_data
+        self.show_overlay()
+
+    def resizeEvent(self, event):
+        self.overlay.resize(event.size())
+        event.accept()
 
     def analysis_timer(self):
         if self.getWindow().show_namebinding():

--- a/lib/eco/nodeeditor.py
+++ b/lib/eco/nodeeditor.py
@@ -98,6 +98,7 @@ class NodeEditor(QFrame):
         """Receive data form a profiler or tool, visualise and display.
         """
         self.overlay.data = tool_data
+        self.overlay.lines = self.lines
         self.show_overlay()
 
     def resizeEvent(self, event):
@@ -182,6 +183,7 @@ class NodeEditor(QFrame):
     def sliderChanged(self, value):
         change = self.viewport_y - value
         self.viewport_y = value
+        self.overlay.start_line = self.viewport_y
         self.update()
 
     def sliderXChanged(self, value):

--- a/lib/eco/nodeeditor.py
+++ b/lib/eco/nodeeditor.py
@@ -94,6 +94,9 @@ class NodeEditor(QFrame):
     def hide_overlay(self):
         self.overlay.hide()
 
+    def is_overlay_visible(self):
+        return self.overlay.isVisible()
+
     def set_tool_data(self, tool_data):
         """Receive data form a profiler or tool, visualise and display.
         """

--- a/lib/eco/overlay.py
+++ b/lib/eco/overlay.py
@@ -1,0 +1,30 @@
+from PyQt4.QtCore import *
+from PyQt4.QtGui import *
+
+
+class Overlay(QWidget):
+    """A transparent overlay which can be placed on top of another QWidget.
+    """
+
+    def __init__(self, parent=None):
+        super(Overlay, self).__init__(parent)
+
+        palette = QPalette(self.palette())
+        palette.setColor(palette.Background, Qt.transparent)
+
+        self.setPalette(palette)
+
+        # line no -> (float, node)
+        self.data = dict()
+
+    def paintEvent(self, event):
+        """Paint the visualisation of current tool data.
+        """
+        painter = QPainter()
+        painter.begin(self)
+        painter.setRenderHint(QPainter.Antialiasing)
+        # A semi-transparent fill over the widget below.
+        painter.fillRect(event.rect(), QBrush(QColor(255, 255, 255, 127)))
+
+        if self.data:
+            pass  # FIXME: Draw a heatmap here.

--- a/lib/eco/overlay.py
+++ b/lib/eco/overlay.py
@@ -8,23 +8,70 @@ class Overlay(QWidget):
 
     def __init__(self, parent=None):
         super(Overlay, self).__init__(parent)
-
         palette = QPalette(self.palette())
         palette.setColor(palette.Background, Qt.transparent)
-
         self.setPalette(palette)
 
+        self.node_editor = parent
+
+        # Start and end colours in the gradient
+        self.alpha = 100
+        self.colour_low  = (222.0, 235.0, 247.0)
+        self.colour_high = (49.0, 130.0, 189.0)
+
         # line no -> (float, node)
-        self.data = dict()
+        self._data = dict()
+        # line no -> QColor
+        self._colours = dict()
+
+    @property
+    def data(self):
+        return self._data
+
+    @data.setter
+    def data(self, data):
+        self._data = data
+        vals = [self._data[lineno][0] for lineno in self._data]
+        val_min = float(min(vals))
+        val_max = float(max(vals))
+        val_diff = val_max - val_min
+        for lineno in self._data:
+            val, node = self._data[lineno]
+            # Linear normalisation:
+            normed = (val - val_min) / val_diff
+            self._colours[lineno] = self.get_colour(normed)
+
+    def get_colour(self, value):
+        red   = float(self.colour_high[0] - self.colour_low[0]) * value + self.colour_low[0]
+        green = float(self.colour_high[1] - self.colour_low[1]) * value + self.colour_low[1]
+        blue  = float(self.colour_high[2] - self.colour_low[2]) * value + self.colour_low[2]
+        return QColor(int(red), int(green), int(blue), self.alpha)
 
     def paintEvent(self, event):
         """Paint the visualisation of current tool data.
         """
+        if self._data is None:
+            return
+
         painter = QPainter()
         painter.begin(self)
         painter.setRenderHint(QPainter.Antialiasing)
-        # A semi-transparent fill over the widget below.
-        painter.fillRect(event.rect(), QBrush(QColor(255, 255, 255, 127)))
 
-        if self.data:
-            pass  # FIXME: Draw a heatmap here.
+        # Current system font.
+        gfont = QApplication.instance().gfont
+
+        # Draw the visualisation.
+        x_top = event.rect().top() + 3 + self.node_editor.paint_start[1] * gfont.fontht  # Start a top of widget.
+        lineno = self.node_editor.paint_start[0] + 1
+        last_lineno = max(self._colours.keys())
+        lines = self.node_editor.lines
+        while lineno <= last_lineno:
+            if lineno in self._colours:
+                # __init__ (self, int aleft, int atop, int awidth, int aheight)
+                rect = QRect(0,
+                             x_top,
+                             event.rect().width(),
+                             gfont.fontht * lines[lineno - 1].height)
+                painter.fillRect(rect, QBrush(self._colours[lineno]))
+            x_top += gfont.fontht * lines[lineno - 1].height
+            lineno += 1

--- a/lib/eco/treemanager.py
+++ b/lib/eco/treemanager.py
@@ -289,6 +289,7 @@ class TreeManager(object):
         self.savenextparse = False
         self.saved_lines = {}
         self.saved_parsers = {}
+        self.profile_data = {} # line no -> (float, node) (raw data)
         self.profile_map = {}  # node -> str
         self.profile_is_dirty = False
         # This code and the can_profile() method should probably be refactored.
@@ -1471,6 +1472,7 @@ class TreeManager(object):
         if profile:
             self.profile_is_dirty = False
             self.profile_map = dict()
+            self.profile_data = dict()
             working_dir = os.path.join(os.environ["GRAAL_WORKSPACE"], "graal-compiler")
             f = tempfile.mkstemp(suffix=".sl")
             self.export_as_text(f[1])
@@ -1509,13 +1511,8 @@ class TreeManager(object):
                     if node.lookup == "<ws>":
                         node = node.next_term
                     self.profile_map[node] = msg
+                    self.profile_data[lineno] = (float(ncalls), node)
             return mock
-
-                    # temp_cursor.line = lineno - 1
-                    # temp_cursor.move_to_x(0, self.lines)
-                    # temp_cursor.right()
-                    # self.profile_map[temp_cursor.node] = msg
-            # return mock
 
         elif path:
             self.export_as_text(path)
@@ -1528,6 +1525,7 @@ class TreeManager(object):
             # Delete any stale profile info
             self.profile_is_dirty = False
             self.profile_map = dict()
+            self.profile_data = dict()
             # python -m cProfile [-o output_file] [-s sort_order] myscript.py
             proc = subprocess.Popen(["python2", "-m", "cProfile", f[1]], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=0)
             stdout_value, stderr_value = proc.communicate()
@@ -1566,6 +1564,7 @@ class TreeManager(object):
                     if node.lookup == "<ws>":
                         node = node.next_term
                     self.profile_map[node] = msg
+                    self.profile_data[lineno] = (float(ncalls), node)
             return mock
         elif run:
             return subprocess.Popen(["python2", f[1]], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=0)


### PR DESCRIPTION
This PR adds a "heatmap" style visualisation of profiler information to Eco. This currently works with Python and SimpleLanguage.

New features are as follows:
- _Project->Profile_ shows profiler information as "footnote" style text annotations and a heatmap drawn on a semi-transparent overlay (see screenshot below)
- _Project->Visualise automatically_ allows user to profile continuously in background. At the moment profiling happens whenever the user saves the currently edited file, and each time the profiler finishes.
- _View->Show tool visualisations_ can be (un)checked to toggle the display of a heatmap
- _File->Settings_ shows a dialog which allows the level of transparency and the start / end colours in the heatmap to be adjusted
-  _File->Settings_ shows a dialog which allows the font and font size of the footnote annotations to be adjusted

![exampleheatmap](https://cloud.githubusercontent.com/assets/97674/11247552/70b61c06-8e14-11e5-9e86-51252762bc64.png)

/cc @ptersilie 
