### PR TITLE
Signal to the user that tool information is out of date.

### DIFF
--- a/lib/eco/eco.py
+++ b/lib/eco/eco.py
@@ -798,6 +798,7 @@ class Window(QtGui.QMainWindow):
         self.ui.teConsole.clear()
         self.ui.actionShow_tool_visualisations.setChecked(True)
         ed = self.getEditor()
+        ed.tm.tool_data_is_dirty = False
         ed.overlay.clear_data()
         self.profile_throbber.show(self.ui.tabWidget.currentIndex())
         self.thread_prof.start()

--- a/lib/eco/nodeeditor.py
+++ b/lib/eco/nodeeditor.py
@@ -171,6 +171,8 @@ class NodeEditor(QFrame):
                 annotes = [annote.annotation for annote in node.get_annotations_with_hint(ToolTip)]
                 msg = "\n".join(annotes)
                 if msg.strip() != "":
+                    if self.tm.tool_data_is_dirty:
+                        msg += "\n[Warning: Information may be out of date.]"
                     QToolTip.showText(event.globalPos(), msg)
             return True
         return QFrame.event(self, event)

--- a/lib/eco/overlay.py
+++ b/lib/eco/overlay.py
@@ -28,6 +28,12 @@ class Overlay(QWidget):
         high = QColor(QApplication.instance().heatmap_high)
         transparency = QApplication.instance().heatmap_alpha.toInt()[0]
 
+        # If data is out of date, draw the heatmap with 10% less opacity
+        if self.node_editor.tm.tool_data_is_dirty:
+            transparency_new = int(transparency * 0.8)
+            if transparency_new > 0:
+                transparency = transparency_new
+
         red   = float(high.red() - low.red()) * value + low.red()
         green = float(high.green() - low.green()) * value + low.green()
         blue  = float(high.blue() - low.blue()) * value + low.blue()


### PR DESCRIPTION
When the current document has been edited:
- add extra text to tooltips **[Warning: Information may be out of date.]**, 
- draw heatmaps with 10% less opacity
- draw footnotes without emboldening the font.
