### PR TITLE
Only activate certain menu items when a file is opened

### DIFF
--- a/lib/eco/eco.py
+++ b/lib/eco/eco.py
@@ -545,9 +545,6 @@ class Window(QtGui.QMainWindow):
         self.connect(self.ui.actionPreview, SIGNAL("triggered()"), self.showPreviewDialog)
         self.connect(self.ui.actionUndo, SIGNAL("triggered()"), self.undo)
         self.connect(self.ui.actionRedo, SIGNAL("triggered()"), self.redo)
-        # XXX temporarily disable undo/redo because it's buggy
-        #self.ui.actionUndo.setEnabled(False)
-        #self.ui.actionRedo.setEnabled(False)
         self.connect(self.ui.actionCopy, SIGNAL("triggered()"), self.copy)
         self.connect(self.ui.actionCut, SIGNAL("triggered()"), self.cut)
         self.connect(self.ui.actionPaste, SIGNAL("triggered()"), self.paste)
@@ -924,6 +921,7 @@ class Window(QtGui.QMainWindow):
             etab.editor.setFocus(Qt.OtherFocusReason)
             etab.editor.setContextMenuPolicy(Qt.CustomContextMenu)
             etab.editor.customContextMenuRequested.connect(self.contextMenu)
+            self.toggle_menu(True)
             return True
         return False
 
@@ -1036,6 +1034,7 @@ class Window(QtGui.QMainWindow):
                 if self.newfile():
                     self.importfile(filename)
                     self.getEditorTab().update()
+            self.toggle_menu(True)
 
     def closeTab(self, index):
         etab = self.ui.tabWidget.widget(index)
@@ -1069,6 +1068,8 @@ class Window(QtGui.QMainWindow):
                 self.ui.actionStateGraph.setEnabled(True)
             else:
                 self.ui.actionStateGraph.setEnabled(False)
+        else:
+            self.toggle_menu(False)
         self.btReparse()
 
     def closeEvent(self, event):
@@ -1146,6 +1147,35 @@ class Window(QtGui.QMainWindow):
         #l = self.ui.frame.tm.getLookaheadList()
         #self.ui.lineEdit.setText(", ".join(l))
         pass
+
+    def toggle_menu(self, enabled=True):
+        self.ui.actionSave.setEnabled(enabled)
+        self.ui.actionSave_as.setEnabled(enabled)
+        self.ui.actionExport.setEnabled(enabled)
+        self.ui.actionExportAs.setEnabled(enabled)
+        self.ui.actionRun.setEnabled(enabled)
+        self.ui.actionUndo.setEnabled(enabled)
+        self.ui.actionRedo.setEnabled(enabled)
+        self.ui.actionCopy.setEnabled(enabled)
+        self.ui.actionPaste.setEnabled(enabled)
+        self.ui.actionCut.setEnabled(enabled)
+        self.ui.actionFind.setEnabled(enabled)
+        self.ui.actionFind_next.setEnabled(enabled)
+        self.ui.actionAdd_language_box.setEnabled(enabled)
+        self.ui.actionSelect_next_language_box.setEnabled(enabled)
+        try:
+            import pydot
+            self.ui.actionParse_Tree.setEnabled(enabled)
+        except ImportError:
+            pass
+        self.ui.actionCode_complete.setEnabled(enabled)
+        self.ui.menuChange_language_box.setEnabled(enabled)
+        self.ui.actionPreview.setEnabled(enabled)
+        self.ui.actionInput_log.setEnabled(enabled)
+        
+        if enabled == False:
+            self.ui.actionProfile.setEnabled(enabled)
+            self.ui.actionStateGraph.setEnabled(enabled)
 
 def main():
     app = QtGui.QApplication(sys.argv)

--- a/lib/eco/gui/gui.ui
+++ b/lib/eco/gui/gui.ui
@@ -46,7 +46,7 @@
      <x>0</x>
      <y>0</y>
      <width>920</width>
-     <height>26</height>
+     <height>23</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -98,6 +98,9 @@
      <string>Edit</string>
     </property>
     <widget class="QMenu" name="menuChange_language_box">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
      <property name="title">
       <string>Change language box</string>
      </property>
@@ -264,6 +267,9 @@
    </property>
   </action>
   <action name="actionSave">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="icon">
     <iconset theme="document-save">
      <normaloff>../../../../../.designer</normaloff>../../../../../.designer</iconset>
@@ -288,6 +294,9 @@
    </property>
   </action>
   <action name="actionRun">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="icon">
     <iconset theme="system-run">
      <normaloff>../../../../../.designer/backup</normaloff>../../../../../.designer/backup</iconset>
@@ -301,6 +310,9 @@
     <bool>false</bool>
    </property>
    <property name="checked">
+    <bool>false</bool>
+   </property>
+   <property name="enabled">
     <bool>false</bool>
    </property>
    <property name="text">
@@ -317,11 +329,17 @@
    </property>
   </action>
   <action name="actionStateGraph">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="text">
     <string>StateGraph</string>
    </property>
   </action>
   <action name="actionUndo">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="icon">
     <iconset theme="edit-undo">
      <normaloff/>
@@ -335,6 +353,9 @@
    </property>
   </action>
   <action name="actionRedo">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="icon">
     <iconset theme="edit-redo">
      <normaloff/>
@@ -348,6 +369,9 @@
    </property>
   </action>
   <action name="actionCut">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="icon">
     <iconset theme="edit-cut">
      <normaloff/>
@@ -361,6 +385,9 @@
    </property>
   </action>
   <action name="actionCopy">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="icon">
     <iconset theme="edit-copy">
      <normaloff/>
@@ -374,6 +401,9 @@
    </property>
   </action>
   <action name="actionPaste">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="icon">
     <iconset theme="edit-paste">
      <normaloff/>
@@ -387,6 +417,9 @@
    </property>
   </action>
   <action name="actionSave_as">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="icon">
     <iconset theme="document-save-as">
      <normaloff>../../../../../.designer/backup</normaloff>../../../../../.designer/backup</iconset>
@@ -399,6 +432,9 @@
    </property>
   </action>
   <action name="actionAdd_language_box">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="icon">
     <iconset theme="list-add">
      <normaloff/>
@@ -412,6 +448,9 @@
    </property>
   </action>
   <action name="actionSelect_next_language_box">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="icon">
     <iconset theme="go-next">
      <normaloff/>
@@ -430,6 +469,9 @@
    </property>
   </action>
   <action name="actionFind">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="icon">
     <iconset theme="find">
      <normaloff>../../../../../.designer/backup</normaloff>../../../../../.designer/backup</iconset>
@@ -442,6 +484,9 @@
    </property>
   </action>
   <action name="actionCode_complete">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="icon">
     <iconset theme="insert-text">
      <normaloff>../../../../../.designer/backup</normaloff>../../../../../.designer/backup</iconset>
@@ -465,6 +510,9 @@
    </property>
   </action>
   <action name="actionFind_next">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="text">
     <string>Find next</string>
    </property>
@@ -473,6 +521,9 @@
    </property>
   </action>
   <action name="actionExportAs">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="icon">
     <iconset theme="document-export">
      <normaloff/>
@@ -486,6 +537,9 @@
    </property>
   </action>
   <action name="actionExport">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="icon">
     <iconset theme="document-export">
      <normaloff/>
@@ -509,6 +563,9 @@
    </property>
   </action>
   <action name="actionPreview">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="text">
     <string>Preview...</string>
    </property>
@@ -535,11 +592,17 @@
    </property>
   </action>
   <action name="actionInput_log">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="text">
     <string>Input log...</string>
    </property>
   </action>
   <action name="actionProfile">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="text">
     <string>Profile</string>
    </property>


### PR DESCRIPTION
Fixes #59 

Deactivate menu options like copy/paste/save/etc by default. Only activate them if there is currently a file opened. Deactivate again when all current files are closed.

@snim2 Hope that doesn't interfere with the plugin stuff you are doing.
