### PR TITLE
Save a version for each change and store snapshots for undo/redo

### DIFF
--- a/lib/eco/nodeeditor.py
+++ b/lib/eco/nodeeditor.py
@@ -128,7 +128,7 @@ class NodeEditor(QFrame):
         self.update()
 
     def trigger_undotimer(self):
-        self.tm.save_current_version()
+        self.tm.undo_snapshot()
         self.undotimer.stop()
 
     def setImageMode(self, boolean):


### PR DESCRIPTION
From now on each change in Eco is saved as it's own version. Several changes are grouped into snapshots, which can be loaded through undo/redo.
