### PR TITLE
Fixes a bug when drawing language box brackets.

### DIFF
--- a/lib/eco/nodeeditor.py
+++ b/lib/eco/nodeeditor.py
@@ -469,10 +469,10 @@ class NodeEditor(QFrame):
                     self.draw_vertical_squiggly_line(paint,x,y)
                 else:
                     if self.tm.has_error(node):
-                        color = "orange"
+                        err_color = "orange"
                     else:
-                        color = "red"
-                    self.draw_squiggly_line(paint,x-length,y,length, color)
+                        err_color = "red"
+                    self.draw_squiggly_line(paint,x-length,y,length, err_color)
 
             node = node.next_term
 


### PR DESCRIPTION
Avoid using the same variable name `color` for squiggly lines as it clashes
with `color` also being used for language boxes.
