### PR TITLE
KeyPress Refactoring

### DIFF
--- a/lib/eco/eco.py
+++ b/lib/eco/eco.py
@@ -584,6 +584,7 @@ class Window(QtGui.QMainWindow):
         self.connect(self.ui.actionPreview, SIGNAL("triggered()"), self.showPreviewDialog)
         self.connect(self.ui.actionUndo, SIGNAL("triggered()"), self.undo)
         self.connect(self.ui.actionRedo, SIGNAL("triggered()"), self.redo)
+        self.connect(self.ui.actionSelect_all, SIGNAL("triggered()"), self.select_all)
         self.connect(self.ui.actionCopy, SIGNAL("triggered()"), self.copy)
         self.connect(self.ui.actionCut, SIGNAL("triggered()"), self.cut)
         self.connect(self.ui.actionPaste, SIGNAL("triggered()"), self.paste)
@@ -925,6 +926,11 @@ class Window(QtGui.QMainWindow):
         self.getEditor().tm.pasteText(text)
         self.getEditor().update()
 
+    def select_all(self):
+        editor = self.getEditor()
+        editor.tm.select_all()
+        editor.update()
+
     def show_input_log(self):
         if self.getEditor():
             v = InputLogView(self)
@@ -1214,6 +1220,7 @@ class Window(QtGui.QMainWindow):
         self.ui.actionPaste.setEnabled(enabled)
         self.ui.actionCut.setEnabled(enabled)
         self.ui.actionFind.setEnabled(enabled)
+        self.ui.actionSelect_all.setEnabled(enabled)
         self.ui.actionFind_next.setEnabled(enabled)
         self.ui.actionAdd_language_box.setEnabled(enabled)
         self.ui.actionSelect_next_language_box.setEnabled(enabled)

--- a/lib/eco/gui/gui.ui
+++ b/lib/eco/gui/gui.ui
@@ -46,7 +46,7 @@
      <x>0</x>
      <y>0</y>
      <width>920</width>
-     <height>22</height>
+     <height>23</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -107,7 +107,8 @@
      </property>
      <property name="icon">
       <iconset theme="reload">
-       <normaloff>.</normaloff>.</iconset>
+       <normaloff/>
+      </iconset>
      </property>
      <addaction name="actionDummy"/>
     </widget>
@@ -117,6 +118,8 @@
     <addaction name="actionCut"/>
     <addaction name="actionCopy"/>
     <addaction name="actionPaste"/>
+    <addaction name="separator"/>
+    <addaction name="actionSelect_all"/>
     <addaction name="separator"/>
     <addaction name="actionFind"/>
     <addaction name="actionFind_next"/>
@@ -342,7 +345,8 @@
    </property>
    <property name="icon">
     <iconset theme="edit-undo">
-     <normaloff>.</normaloff>.</iconset>
+     <normaloff/>
+    </iconset>
    </property>
    <property name="text">
     <string>Undo</string>
@@ -357,7 +361,8 @@
    </property>
    <property name="icon">
     <iconset theme="edit-redo">
-     <normaloff>.</normaloff>.</iconset>
+     <normaloff/>
+    </iconset>
    </property>
    <property name="text">
     <string>Redo</string>
@@ -372,7 +377,8 @@
    </property>
    <property name="icon">
     <iconset theme="edit-cut">
-     <normaloff>.</normaloff>.</iconset>
+     <normaloff/>
+    </iconset>
    </property>
    <property name="text">
     <string>Cut</string>
@@ -387,7 +393,8 @@
    </property>
    <property name="icon">
     <iconset theme="edit-copy">
-     <normaloff>.</normaloff>.</iconset>
+     <normaloff/>
+    </iconset>
    </property>
    <property name="text">
     <string>Copy</string>
@@ -402,7 +409,8 @@
    </property>
    <property name="icon">
     <iconset theme="edit-paste">
-     <normaloff>.</normaloff>.</iconset>
+     <normaloff/>
+    </iconset>
    </property>
    <property name="text">
     <string>Paste</string>
@@ -432,7 +440,8 @@
    </property>
    <property name="icon">
     <iconset theme="list-add">
-     <normaloff>.</normaloff>.</iconset>
+     <normaloff/>
+    </iconset>
    </property>
    <property name="text">
     <string>Add language box</string>
@@ -447,7 +456,8 @@
    </property>
    <property name="icon">
     <iconset theme="go-next">
-     <normaloff>.</normaloff>.</iconset>
+     <normaloff/>
+    </iconset>
    </property>
    <property name="text">
     <string>Select next language box</string>
@@ -513,13 +523,28 @@
     <string>F3</string>
    </property>
   </action>
+  <action name="actionSelect_all">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="icon">
+    <iconset theme="edit-select-all"/>
+   </property>
+   <property name="text">
+    <string>Select all</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+A</string>
+   </property>
+  </action>
   <action name="actionExportAs">
    <property name="enabled">
     <bool>false</bool>
    </property>
    <property name="icon">
     <iconset theme="document-export">
-     <normaloff>.</normaloff>.</iconset>
+     <normaloff/>
+    </iconset>
    </property>
    <property name="text">
     <string>Export as...</string>
@@ -534,7 +559,8 @@
    </property>
    <property name="icon">
     <iconset theme="document-export">
-     <normaloff>.</normaloff>.</iconset>
+     <normaloff/>
+    </iconset>
    </property>
    <property name="text">
     <string>Export</string>
@@ -546,7 +572,8 @@
   <action name="actionSettings">
    <property name="icon">
     <iconset theme="gnome-settings">
-     <normaloff>.</normaloff>.</iconset>
+     <normaloff/>
+    </iconset>
    </property>
    <property name="text">
     <string>Settings...</string>

--- a/lib/eco/nodeeditor.py
+++ b/lib/eco/nodeeditor.py
@@ -572,9 +572,13 @@ class NodeEditor(QFrame):
     def draw_selection(self, paint, draw_selection_start, draw_selection_end, max_y):
         x1, y1, line1 = draw_selection_start
         x2, y2, line2 = draw_selection_end
+        start = min(self.tm.selection_start, self.tm.selection_end)
+        end = max(self.tm.selection_start, self.tm.selection_end)
         if x1 + y1 + line1 + x2 + y2 + line2 == 0:
             # everything out of viewport, draw nothing
-            return
+            # unless start and end are on opposite sides of the viewport
+            if not(start.line <= self.paint_start[0] and end.line >= self.paint_start[0] + max_y):
+                    return
         if x1 + y1 + line1 == 0:
             # start outside of viewport
             line1 = self.paint_start[0]
@@ -585,7 +589,8 @@ class NodeEditor(QFrame):
         if y1 == y2:
             paint.fillRect(QRectF(x1, 3 + y1 * self.fontht, x2-x1, self.fontht), QColor(0,0,255,100))
         else:
-            paint.fillRect(QRectF(x1, 3 + y1 * self.fontht, self.tm.lines[line1].width*self.fontwt - x1, self.fontht), QColor(0,0,255,100))
+            width = max(self.fontwt, self.tm.lines[line1].width*self.fontwt)
+            paint.fillRect(QRectF(x1, 3 + y1 * self.fontht, width - x1, self.fontht), QColor(0,0,255,100))
             y = y1 + self.tm.lines[line1].height
             for i in range(line1+1, line2):
                 width = self.tm.lines[i].width*self.fontwt

--- a/lib/eco/nodeeditor.py
+++ b/lib/eco/nodeeditor.py
@@ -723,8 +723,6 @@ class NodeEditor(QFrame):
         self.show_cursor = True
 
         if e.key() in [Qt.Key_Shift, Qt.Key_Alt, Qt.Key_Control, Qt.Key_Meta, Qt.Key_AltGr]:
-            if e.key() == Qt.Key_Shift:
-                self.tm.key_shift()
             return
 
         text = e.text()

--- a/lib/eco/test/test_eco.py
+++ b/lib/eco/test/test_eco.py
@@ -25,6 +25,7 @@ from incparser.incparser import IncParser
 from inclexer.inclexer import IncrementalLexer
 from incparser.astree import BOS, EOS
 from grammar_parser.gparser import MagicTerminal
+from utils import KEY_UP as UP, KEY_DOWN as DOWN, KEY_LEFT as LEFT, KEY_RIGHT as RIGHT
 
 from PyQt4 import QtCore
 
@@ -68,7 +69,7 @@ class Test_Typing:
     def test_cursormovement1(self):
         self.treemanager.key_home()
         assert isinstance(self.treemanager.cursor.node, BOS)
-        self.treemanager.cursor_movement("right")
+        self.treemanager.cursor_movement(RIGHT)
         assert self.treemanager.cursor.node.symbol.name == "1"
         self.treemanager.key_end()
         assert self.treemanager.cursor.node.symbol.name == "2"
@@ -87,11 +88,11 @@ class Test_Typing:
         assert self.treemanager.cursor.node.symbol.name == "5"
         self.treemanager.key_end()
         assert self.treemanager.cursor.node.symbol.name == "5"
-        self.treemanager.cursor_movement("up")
+        self.treemanager.cursor_movement(UP)
         assert self.treemanager.cursor.node.symbol.name == "2"
-        self.treemanager.cursor_movement("left")
+        self.treemanager.cursor_movement(LEFT)
         assert self.treemanager.cursor.node.symbol.name == "+"
-        self.treemanager.cursor_movement("down")
+        self.treemanager.cursor_movement(DOWN)
         assert self.treemanager.cursor.node.symbol.name == "+"
 
     def test_deletion(self):
@@ -102,7 +103,7 @@ class Test_Typing:
         assert self.treemanager.cursor.node.symbol.name == "+"
         self.treemanager.key_delete()
         assert self.treemanager.cursor.node.symbol.name == "+"
-        self.treemanager.cursor_movement("left")
+        self.treemanager.cursor_movement(LEFT)
         self.treemanager.key_delete()
         assert self.treemanager.cursor.node.symbol.name == "3"
 
@@ -114,7 +115,7 @@ class Test_Typing:
         self.reset()
         self.treemanager.key_normal("a")
         self.treemanager.key_shift()
-        self.treemanager.key_cursors("left", mod_shift=True)
+        self.treemanager.key_cursors(LEFT, shift=True)
         assert self.treemanager.hasSelection()
         nodes, _, _ = self.treemanager.get_nodes_from_selection()
         self.treemanager.key_delete()
@@ -682,23 +683,23 @@ class Test_Bugs(Test_Python):
 
         self.treemanager.key_end()
         self.treemanager.key_shift()
-        self.treemanager.key_cursors("left", True)
-        self.treemanager.key_cursors("left", True)
-        self.treemanager.key_cursors("left", True)
-        self.treemanager.key_cursors("left", True)
+        self.treemanager.key_cursors(LEFT, True)
+        self.treemanager.key_cursors(LEFT, True)
+        self.treemanager.key_cursors(LEFT, True)
+        self.treemanager.key_cursors(LEFT, True)
         self.treemanager.pasteText("back")
         assert self.treemanager.export_as_text() == "back"
 
         self.treemanager.key_home()
         self.treemanager.key_shift()
-        self.treemanager.key_cursors("right", True)
-        self.treemanager.key_cursors("right", True)
-        self.treemanager.key_cursors("right", True)
-        self.treemanager.key_cursors("right", True)
+        self.treemanager.key_cursors(RIGHT, True)
+        self.treemanager.key_cursors(RIGHT, True)
+        self.treemanager.key_cursors(RIGHT, True)
+        self.treemanager.key_cursors(RIGHT, True)
         self.treemanager.pasteText("again")
         assert self.treemanager.export_as_text() == "again"
 
-        self.move("left", 2)
+        self.move(LEFT, 2)
         self.treemanager.doubleclick_select()
         self.treemanager.pasteText("test")
         assert self.treemanager.export_as_text() == "test"
@@ -766,7 +767,7 @@ class Test_Indentation(Test_Python):
 """
         self.treemanager.import_file(inputstring)
         assert self.parser.last_status == True
-        self.move("down", 2)
+        self.move(DOWN, 2)
         self.treemanager.key_normal("z")
         assert self.parser.last_status == True
 
@@ -790,8 +791,8 @@ class Test_Indentation(Test_Python):
         assert isinstance(self.treemanager.cursor.node, BOS)
 
         # move cursor to 'break'
-        self.move('down', 9)
-        self.move('right', 16)
+        self.move(DOWN, 9)
+        self.move(RIGHT, 16)
 
         assert self.treemanager.cursor.node.symbol.name == "                "
         assert self.treemanager.cursor.node.next_term.symbol.name == "break"
@@ -837,14 +838,14 @@ class Test_Indentation(Test_Python):
         assert isinstance(self.treemanager.cursor.node, BOS)
 
         # move cursor to 'break'
-        self.move('down', 4)
-        self.move('right', 8)
+        self.move(DOWN, 4)
+        self.move(RIGHT, 8)
 
         # indent 'for' and 'x = x + 1'
         assert self.treemanager.cursor.node.next_term.symbol.name == "for"
         for i in range(4): self.treemanager.key_normal(" ")
         assert self.parser.last_status == False
-        self.move('down', 1)
+        self.move(DOWN, 1)
         assert self.treemanager.cursor.node.next_term.symbol.name == "x"
         for i in range(4): self.treemanager.key_normal(" ")
         assert self.parser.last_status == True
@@ -867,19 +868,19 @@ class Test_Indentation(Test_Python):
         assert isinstance(self.treemanager.cursor.node, BOS)
 
         # move cursor to 'break'
-        self.move('down', 4)
-        self.move('right', 4)
+        self.move(DOWN, 4)
+        self.move(RIGHT, 4)
 
         # indent 'def y', 'y = 2' and 'return y'
         assert self.treemanager.cursor.node.next_term.symbol.name == "def"
         for i in range(4): self.treemanager.key_normal(" ")
         assert self.parser.last_status == False
-        self.move('down', 1)
+        self.move(DOWN, 1)
         assert self.treemanager.cursor.node.next_term.symbol.name == "y"
         for i in range(4): self.treemanager.key_normal(" ")
         assert self.parser.last_status == True
-        self.move('down', 1)
-        self.move('left', 4)
+        self.move(DOWN, 1)
+        self.move(LEFT, 4)
         assert self.treemanager.cursor.node.next_term.symbol.name == "return"
         for i in range(4): self.treemanager.key_normal(" ")
         assert self.parser.last_status == True
@@ -902,8 +903,8 @@ class Test_Indentation(Test_Python):
                 del_ws = random.randint(0, whitespace)
                 if del_ws > 0:
                     self.treemanager.cursor_reset()
-                    self.move('down', linenr)
-                    self.move('right', del_ws)
+                    self.move(DOWN, linenr)
+                    self.move(RIGHT, del_ws)
                     assert self.treemanager.cursor.node.symbol.name == " " * whitespace
                     for i in range(del_ws):
                         self.treemanager.key_backspace()
@@ -914,7 +915,7 @@ class Test_Indentation(Test_Python):
         for linenr in deleted:
             del_ws = deleted[linenr]
             self.treemanager.cursor_reset()
-            self.move('down', linenr)
+            self.move(DOWN, linenr)
             for i in range(del_ws):
                 self.treemanager.key_normal(" ")
         assert self.parser.last_status == True
@@ -968,7 +969,7 @@ if b:
         inputstring = """class X(object):\rpass"""
         self.treemanager.import_file(inputstring)
         assert self.parser.last_status == False
-        self.treemanager.cursor_movement("down")
+        self.treemanager.cursor_movement(DOWN)
         self.treemanager.key_home()
         self.treemanager.key_normal(" ")
         assert self.parser.last_status == True
@@ -977,7 +978,7 @@ if b:
         self.reset()
         inputstring = """class X:\r    def x():\r        pass\r    def y():\r        pass"""
         self.treemanager.import_file(inputstring)
-        self.move("down", 3)
+        self.move(DOWN, 3)
         assert self.parser.last_status == True
         # delete whitespace before def y():
         self.treemanager.key_delete()
@@ -999,7 +1000,7 @@ if b:
         inputstring = """class X:\r    def x():\r        pass\rdef y():\r        pass"""
         self.treemanager.import_file(inputstring)
         assert self.parser.last_status == True
-        self.move("down", 3)
+        self.move(DOWN, 3)
         # insert whitespace before def y()
         self.treemanager.key_normal(" ")
         self.treemanager.key_normal(" ")
@@ -1026,7 +1027,7 @@ string
         y"""
         self.treemanager.import_file(inputstring)
         assert self.parser.last_status == False
-        self.move("down", 3)
+        self.move(DOWN, 3)
         self.treemanager.key_end()
         self.treemanager.key_normal("\"")
         self.treemanager.key_normal("\"")
@@ -1043,15 +1044,15 @@ string
 x()"""
         self.treemanager.import_file(inputstring)
         assert self.parser.last_status == True
-        self.move("down", 1)
-        self.move("right", 4)
+        self.move(DOWN, 1)
+        self.move(RIGHT, 4)
         self.treemanager.key_normal("    ")
         assert self.parser.last_status == False
         self.treemanager.key_shift()
-        self.treemanager.key_cursors('left', True)
-        self.treemanager.key_cursors('left', True)
-        self.treemanager.key_cursors('left', True)
-        self.treemanager.key_cursors('left', True)
+        self.treemanager.key_cursors(LEFT, True)
+        self.treemanager.key_cursors(LEFT, True)
+        self.treemanager.key_cursors(LEFT, True)
+        self.treemanager.key_cursors(LEFT, True)
         self.treemanager.key_backspace()
         assert self.parser.last_status == True
 
@@ -1066,17 +1067,17 @@ x()
 """
         self.treemanager.import_file(inputstring)
         assert self.parser.last_status == True
-        self.move("down", 3)
+        self.move(DOWN, 3)
         self.treemanager.key_end()
         self.treemanager.key_normal("p")
         assert self.parser.last_status == False
-        self.move("down", 1)
-        self.move("left", 4)
+        self.move(DOWN, 1)
+        self.move(LEFT, 4)
         self.treemanager.key_shift()
-        self.treemanager.key_cursors('left', True)
-        self.treemanager.key_cursors('left', True)
-        self.treemanager.key_cursors('left', True)
-        self.treemanager.key_cursors('left', True)
+        self.treemanager.key_cursors(LEFT, True)
+        self.treemanager.key_cursors(LEFT, True)
+        self.treemanager.key_cursors(LEFT, True)
+        self.treemanager.key_cursors(LEFT, True)
         self.treemanager.key_backspace()
         assert self.parser.last_status == True
 
@@ -1088,7 +1089,7 @@ x()
 """
         for k in inputstring:
             self.treemanager.key_normal(k)
-        self.move("up", 2)
+        self.move(UP, 2)
         self.treemanager.key_home()
         assert self.parser.last_status == True
         self.treemanager.key_normal("    ")
@@ -1106,14 +1107,14 @@ def z():
     z"""
         self.treemanager.import_file(inputstring)
         assert self.parser.last_status == True
-        self.move("down", 4)
+        self.move(DOWN, 4)
         self.treemanager.key_end()
         self.treemanager.key_normal("\"")
         self.treemanager.key_normal("\"")
         self.treemanager.key_normal("\"")
-        self.move("up", 2)
+        self.move(UP, 2)
         self.treemanager.key_end()
-        self.move("left", 1)
+        self.move(LEFT, 1)
         self.treemanager.key_normal("\"")
         self.treemanager.key_normal("\"")
         self.treemanager.key_normal("\"")
@@ -1122,7 +1123,7 @@ def z():
         self.treemanager.key_backspace()
         self.treemanager.key_backspace()
         self.treemanager.key_backspace()
-        self.move("down", 2)
+        self.move(DOWN, 2)
         self.treemanager.key_end()
         self.treemanager.key_backspace()
         self.treemanager.key_backspace()
@@ -1245,14 +1246,14 @@ class Test_Languageboxes(Test_Python):
         assert lbox.symbol.name == "<Prolog>"
         for c in "abc def":
             self.treemanager.key_normal(c)
-        self.treemanager.key_cursors("left")
+        self.treemanager.key_cursors(LEFT)
         # select "bc de"
         self.treemanager.key_shift()
-        self.treemanager.key_cursors("left", mod_shift=True)
-        self.treemanager.key_cursors("left", mod_shift=True)
-        self.treemanager.key_cursors("left", mod_shift=True)
-        self.treemanager.key_cursors("left", mod_shift=True)
-        self.treemanager.key_cursors("left", mod_shift=True)
+        self.treemanager.key_cursors(LEFT, shift=True)
+        self.treemanager.key_cursors(LEFT, shift=True)
+        self.treemanager.key_cursors(LEFT, shift=True)
+        self.treemanager.key_cursors(LEFT, shift=True)
+        self.treemanager.key_cursors(LEFT, shift=True)
         self.treemanager.deleteSelection()
         assert lbox.symbol.name == "<Prolog>"
 
@@ -1309,7 +1310,7 @@ class Test_Backslash(Test_Python):
             self.treemanager.key_normal(c)
 
         assert self.parser.last_status == True
-        self.move("up", 1)
+        self.move(UP, 1)
         self.treemanager.key_end()
         self.treemanager.key_backspace()
         assert self.parser.last_status == False
@@ -1342,8 +1343,8 @@ class Test_Java:
         for c in prog:
             self.treemanager.key_normal(c)
         assert self.parser.last_status == True
-        self.move("left", 1)
-        self.move("up", 3)
+        self.move(LEFT, 1)
+        self.move(UP, 3)
         self.treemanager.key_end()
         self.treemanager.key_normal("\r")
         for c in "int x = 1;":
@@ -1442,7 +1443,7 @@ class Test_Undo(Test_Python):
         self.type_save("1")
         self.type_save("\r")
         self.type_save("2")
-        self.move("up", 1)
+        self.move(UP, 1)
         self.compare("1\n2")
         self.type_save("\r")
         self.type_save("3")
@@ -1460,7 +1461,7 @@ class Test_Undo(Test_Python):
         self.treemanager.key_shift_ctrl_z()
         self.compare("1\n3\n2")
 
-        self.move("down", 1)
+        self.move(DOWN, 1)
         self.treemanager.key_backspace()
         self.compare("1\n3\n")
         self.treemanager.key_backspace()
@@ -1475,7 +1476,7 @@ class Test_Undo(Test_Python):
         self.type_save("1")
         self.type_save("+")
         self.type_save("2")
-        self.move("left", 2)
+        self.move(LEFT, 2)
         self.compare("1+2")
         self.treemanager.key_delete()
         self.treemanager.undo_snapshot()
@@ -1502,14 +1503,14 @@ class Test_Undo(Test_Python):
         return 23"""
         self.treemanager.import_file(p)
         self.treemanager.key_end()
-        self.move("left", 1)
+        self.move(LEFT, 1)
         self.treemanager.key_normal("s")
         self.treemanager.undo_snapshot()
         dp = self.copy()
 
-        self.move("down", 2)
+        self.move(DOWN, 2)
         self.treemanager.key_end()
-        self.move("left", 1)
+        self.move(LEFT, 1)
         self.treemanager.key_normal("+")
         self.treemanager.undo_snapshot()
 
@@ -1536,36 +1537,36 @@ class Test_Undo(Test_Python):
         imptext = self.treemanager.export_as_text()
 
         self.treemanager.key_end()
-        self.move("left", 1)
+        self.move(LEFT, 1)
         self.treemanager.key_normal("a")
         self.treemanager.undo_snapshot()
         a = self.copy()
         atext = self.treemanager.export_as_text()
 
-        self.move("down", 1)
+        self.move(DOWN, 1)
         self.treemanager.key_end()
-        self.move("left", 3)
+        self.move(LEFT, 3)
         self.treemanager.key_normal("b")
         self.treemanager.undo_snapshot()
         b = self.copy()
         btext = self.treemanager.export_as_text()
 
-        self.move("down", 1)
+        self.move(DOWN, 1)
         self.treemanager.key_end()
         self.treemanager.key_normal("c")
         self.treemanager.undo_snapshot()
         #c = self.copy()
         ctext = self.treemanager.export_as_text()
 
-        self.move("down", 2)
+        self.move(DOWN, 2)
         self.treemanager.key_end()
-        self.move("left", 3)
+        self.move(LEFT, 3)
         self.treemanager.key_normal("d")
         self.treemanager.undo_snapshot()
         #d = self.copy()
         dtext = self.treemanager.export_as_text()
 
-        self.move("down", 1)
+        self.move(DOWN, 1)
         self.treemanager.key_end()
         self.treemanager.key_normal("e")
         self.treemanager.undo_snapshot()
@@ -1626,7 +1627,7 @@ class Test_Undo(Test_Python):
         self.reset() # saves automatically
 
         self.treemanager.import_file("class X:\n    def x():\n         pass") # saves automatically
-        self.move("down", 2)
+        self.move(DOWN, 2)
         self.treemanager.key_end()
         self.treemanager.key_normal("1")
         self.compare("class X:\n    def x():\n         pass1")
@@ -1676,10 +1677,10 @@ class Test_Undo(Test_Python):
             for col in cols:
                 self.treemanager.cursor_reset()
                 print("self.treemanager.cursor_reset()")
-                self.move('down', linenr)
-                print("self.move('down', %s)" % linenr)
-                self.move('right', col)
-                print("self.move('right', %s)" % col)
+                self.move(DOWN, linenr)
+                print("self.move(DOWN, %s)" % linenr)
+                self.move(RIGHT, col)
+                print("self.move(RIGHT, %s)" % col)
                 x = self.treemanager.key_delete()
                 print("self.treemanager.key_delete()")
                 if x == "eos":
@@ -1732,12 +1733,12 @@ class Test_Undo(Test_Python):
         start_version = self.treemanager.version
 
         self.treemanager.cursor_reset()
-        self.move('down', 3)
-        self.move('right', 12)
+        self.move(DOWN, 3)
+        self.move(RIGHT, 12)
         self.treemanager.key_delete()
         self.treemanager.cursor_reset()
-        self.move('down', 3)
-        self.move('right', 19)
+        self.move(DOWN, 3)
+        self.move(RIGHT, 19)
         self.treemanager.key_delete()
 
         self.treemanager.undo_snapshot()
@@ -1775,8 +1776,8 @@ class Test_Undo(Test_Python):
             random.shuffle(cols)
             for col in cols:
                 self.treemanager.cursor_reset()
-                self.move('down', linenr)
-                self.move('right', col)
+                self.move(DOWN, linenr)
+                self.move(RIGHT, col)
                 k = self.get_random_key()
                 x = self.treemanager.key_normal(k)
                 if x == "eos":
@@ -1841,8 +1842,8 @@ class Test_Undo(Test_Python):
             random.shuffle(cols)
             for col in cols[:1]: # add one newline per line
                 self.treemanager.cursor_reset()
-                self.move('down', linenr)
-                self.move('right', col)
+                self.move(DOWN, linenr)
+                self.move(RIGHT, col)
                 x = self.treemanager.key_normal("\r")
                 if x == "eos":
                     continue
@@ -1899,14 +1900,14 @@ class Test_Undo(Test_Python):
         start_version = self.treemanager.version
 
         self.treemanager.cursor_reset()
-        self.move("down", 4)
-        self.move("right", 1)
+        self.move(DOWN, 4)
+        self.move(RIGHT, 1)
         self.treemanager.key_normal("\r")
         self.treemanager.undo_snapshot()
 
         self.treemanager.cursor_reset()
-        self.move("down", 6)
-        self.move("right", 1)
+        self.move(DOWN, 6)
+        self.move(RIGHT, 1)
         self.treemanager.key_normal("\r")
         self.treemanager.undo_snapshot()
 
@@ -1961,23 +1962,23 @@ class Test_Undo(Test_Python):
         start_version = self.treemanager.version
 
         self.treemanager.cursor_reset()
-        self.move("down", 1)
-        self.move("right", 6)
+        self.move(DOWN, 1)
+        self.move(RIGHT, 6)
         self.treemanager.key_delete()
         self.treemanager.key_delete()
         self.treemanager.key_delete()
         self.treemanager.undo_snapshot()
 
         self.treemanager.cursor_reset()
-        self.move("down", 2)
-        self.move("right", 7)
+        self.move(DOWN, 2)
+        self.move(RIGHT, 7)
         self.treemanager.key_delete()
         self.treemanager.key_delete()
         self.treemanager.undo_snapshot()
 
         self.treemanager.cursor_reset()
-        self.move("down", 3)
-        self.move("right", 10)
+        self.move(DOWN, 3)
+        self.move(RIGHT, 10)
         self.treemanager.key_delete()
         self.treemanager.key_delete()
         self.treemanager.undo_snapshot()
@@ -2034,14 +2035,14 @@ class Test_Undo(Test_Python):
         start_version = self.treemanager.version
 
         self.treemanager.cursor_reset()
-        self.move("down", 7)
-        self.move("right", 10)
+        self.move(DOWN, 7)
+        self.move(RIGHT, 10)
         self.treemanager.key_normal("\r")
         self.treemanager.undo_snapshot()
 
         self.treemanager.cursor_reset()
-        self.move("down", 6)
-        self.move("right", 0)
+        self.move(DOWN, 6)
+        self.move(RIGHT, 0)
         self.treemanager.key_normal("\r") # this has to be \r not \n (Eco works with \r)
         self.treemanager.undo_snapshot()
 
@@ -2092,8 +2093,8 @@ class Test_Undo(Test_Python):
             random.shuffle(cols)
             for col in cols:
                 self.treemanager.cursor_reset()
-                self.move('down', linenr)
-                self.move('right', col)
+                self.move(DOWN, linenr)
+                self.move(RIGHT, col)
                 k = self.get_random_key()
                 if k in ["a", "c", "e", "g", "i", "k", "m", "1", "3", "5", "7"]:
                     # for a few characters DELETE instead of INSERT
@@ -2152,17 +2153,17 @@ class Test_Undo(Test_Python):
         start_version = self.treemanager.version
 
         self.treemanager.cursor_reset()
-        self.move('down', 2)
-        self.move('right', 0)
+        self.move(DOWN, 2)
+        self.move(RIGHT, 0)
         self.treemanager.key_normal(',')
         self.treemanager.undo_snapshot()
         self.treemanager.cursor_reset()
-        self.move('down', 1)
-        self.move('right', 3)
+        self.move(DOWN, 1)
+        self.move(RIGHT, 3)
         self.treemanager.key_delete()
         self.treemanager.cursor_reset()
-        self.move('down', 1)
-        self.move('right', 4)
+        self.move(DOWN, 1)
+        self.move(RIGHT, 4)
         self.treemanager.key_normal(' ')
         self.treemanager.undo_snapshot()
 
@@ -2195,10 +2196,10 @@ class Test_Undo(Test_Python):
                 last_was_undo = False
                 print("self.treemanager.cursor_reset()")
                 self.treemanager.cursor_reset()
-                print("self.move('down', %s)" % (linenr))
-                print("self.move('right', %s)" % (col))
-                self.move('down', linenr)
-                self.move('right', col)
+                print("self.move(DOWN, %s)" % (linenr))
+                print("self.move(RIGHT, %s)" % (col))
+                self.move(DOWN, linenr)
+                self.move(RIGHT, col)
                 k = self.get_random_key()
                 if k in ["a", "c", "e", "g", "i", "k", "m", "1", "3", "5", "7"]:
                     # for a few characters DELETE instead of INSERT
@@ -2250,15 +2251,15 @@ class Test_Undo(Test_Python):
         assert self.parser.last_status == True
 
         self.treemanager.cursor_reset()
-        self.move('down', 8)
-        self.move('right', 0)
+        self.move(DOWN, 8)
+        self.move(RIGHT, 0)
         self.treemanager.key_delete()
         self.treemanager.undo_snapshot()
         self.treemanager.cursor_reset()
         self.treemanager.key_ctrl_z()
         self.treemanager.cursor_reset()
-        self.move('down', 9)
-        self.move('right', 0)
+        self.move(DOWN, 9)
+        self.move(RIGHT, 0)
         self.treemanager.key_delete()
 
     def test_bug_undo_loop_2(self):
@@ -2271,12 +2272,12 @@ class Test_Undo(Test_Python):
         start_version = self.treemanager.version
 
         self.treemanager.cursor_reset()
-        self.move('down', 5)
-        self.move('right', 3)
+        self.move(DOWN, 5)
+        self.move(RIGHT, 3)
         self.treemanager.key_normal('#')
         self.treemanager.cursor_reset()
-        self.move('down', 5)
-        self.move('right', 3)
+        self.move(DOWN, 5)
+        self.move(RIGHT, 3)
         self.treemanager.key_normal(')')
         self.treemanager.undo_snapshot()
 
@@ -2302,20 +2303,20 @@ class Test_Undo(Test_Python):
         assert self.parser.last_status == True
 
         self.treemanager.cursor_reset()
-        self.move("down", 12)
-        self.move("right", 0)
+        self.move(DOWN, 12)
+        self.move(RIGHT, 0)
         self.treemanager.key_normal("g")
         self.treemanager.key_ctrl_z()
 
         self.treemanager.cursor_reset()
-        self.move("down", 12)
-        self.move("right", 2)
+        self.move(DOWN, 12)
+        self.move(RIGHT, 2)
         self.treemanager.key_normal("%")
         self.treemanager.key_ctrl_z()
 
         self.treemanager.cursor_reset()
-        self.move("down", 13)
-        self.move("right", 0)
+        self.move(DOWN, 13)
+        self.move(RIGHT, 0)
         self.treemanager.key_normal("y")
 
 
@@ -2335,7 +2336,7 @@ class Test_Undo_LBoxes(Test_Helper):
     def test_simple(self):
         self.reset()
         self.treemanager.import_file(programs.phpclass)
-        self.move("up", 1)
+        self.move(UP, 1)
 
         self.treemanager.add_languagebox(lang_dict["Python + PHP"])
 
@@ -2345,7 +2346,7 @@ class Test_Undo_LBoxes(Test_Helper):
         self.treemanager.key_normal("s")
         self.treemanager.undo_snapshot()
 
-        self.move("down", 1)
+        self.move(DOWN, 1)
         self.treemanager.key_end()
         self.treemanager.key_normal("a")
         self.treemanager.undo_snapshot()
@@ -2359,7 +2360,7 @@ class Test_Undo_LBoxes(Test_Helper):
         self.versions.append(self.treemanager.export_as_text())
         self.treemanager.import_file(programs.phpclass)
         self.versions.append(self.treemanager.export_as_text())
-        self.move("down", 1)
+        self.move(DOWN, 1)
 
         self.treemanager.add_languagebox(lang_dict["Python + PHP"])
 
@@ -2376,7 +2377,7 @@ class Test_Undo_LBoxes(Test_Helper):
         self.treemanager.undo_snapshot()
         self.versions.append(self.treemanager.export_as_text())
 
-        self.move("up", 2)
+        self.move(UP, 2)
         self.treemanager.key_end()
         self.treemanager.key_normal("\r")
         self.treemanager.undo_snapshot()
@@ -2398,7 +2399,7 @@ class Test_Undo_LBoxes(Test_Helper):
     def test_clean_version_bug(self):
         self.reset()
         self.treemanager.import_file(programs.phpclass)
-        self.move("down", 1)
+        self.move(DOWN, 1)
 
         self.treemanager.add_languagebox(lang_dict["Python + PHP"])
         self.treemanager.key_normal("p")
@@ -2417,9 +2418,9 @@ class Test_Undo_LBoxes(Test_Helper):
 
         self.tree_compare(self.parser.previous_version.parent, dp)
 
-        self.move("up", 1)
+        self.move(UP, 1)
         self.treemanager.key_end()
-        self.move("left", 2)
+        self.move(LEFT, 2)
         self.treemanager.key_normal("x")
         self.treemanager.undo_snapshot()
 
@@ -2465,9 +2466,9 @@ self.key_normal(' ')
 self.key_normal('=')
 self.key_normal(' ')
 self.key_normal('1')
-self.key_cursors('up', False)
-self.key_cursors('left', False)
-self.key_cursors('left', False)
+self.key_cursors(KEY_UP, False)
+self.key_cursors(KEY_LEFT, False)
+self.key_cursors(KEY_LEFT, False)
 # mousePressEvent
 self.cursor.line = 1
 self.cursor.move_to_x(11, self.lines)
@@ -2521,7 +2522,7 @@ class Test_Comments_Indents(Test_Python):
             self.treemanager.key_normal(c)
         assert self.parser.last_status == True
 
-        self.move("left", 6)
+        self.move(LEFT, 6)
         self.treemanager.key_normal("\r")
         assert self.parser.last_status == True
 
@@ -2531,8 +2532,8 @@ y = 13""":
             self.treemanager.key_normal(c)
         assert self.parser.last_status == True
 
-        self.move("left", 6)
-        self.move("up", 1)
+        self.move(LEFT, 6)
+        self.move(UP, 1)
         self.treemanager.key_normal("#")
         assert self.parser.last_status == True
         

--- a/lib/eco/treemanager.py
+++ b/lib/eco/treemanager.py
@@ -1030,7 +1030,7 @@ class TreeManager(object):
             self.unselect()
 
     def jump_cursor_within_selection(self, key):
-        '''
+        """
             Jump cursor with respect to text selection.
 
             There are 4*2 = 8 different cases, with four different
@@ -1043,7 +1043,7 @@ class TreeManager(object):
             * RIGHT: Jump to right end of selection.
             * UP:    Jump one line upwards w.r.t. left end of selection.
             * DOWN:  Jump one line downwards w.r.t. right end of selection.
-        '''
+        """
         selection_start, selection_end = sorted(
             [self.selection_start, self.selection_end])
 
@@ -1080,6 +1080,14 @@ class TreeManager(object):
         self.selection_end.pos = len(self.selection_end.node.symbol.name)
         self.cursor.pos = self.selection_end.pos
         self.cursor.node = self.selection_end.node
+
+    def select_all(self):
+        self.selection_start = Cursor(self.get_bos(), -1, 0)
+        self.cursor.node = self.get_eos()
+        self.cursor.jump_left() # for now ignore invisible nodes
+        self.cursor.pos = len(self.cursor.node.symbol.name)
+        self.cursor.line = len(self.lines) - 1
+        self.selection_end = self.cursor.copy()
 
     def unselect(self):
         self.selection_start = self.cursor.copy()

--- a/lib/eco/treemanager.py
+++ b/lib/eco/treemanager.py
@@ -996,8 +996,6 @@ class TreeManager(object):
 
     def key_shift(self):
         self.log_input("key_shift")
-        self.selection_start = self.cursor.copy()
-        self.selection_end = self.cursor.copy()
 
     def key_escape(self):
         self.log_input("key_escape")
@@ -1008,11 +1006,53 @@ class TreeManager(object):
     def key_cursors(self, key, mod_shift=False):
         self.log_input("key_cursors", repr(key), str(mod_shift))
         self.edit_rightnode = False
-        self.cursor_movement(key)
+
+        # Four possible cases:
+        # no   shift, no   selection -> normal movement of cursor
+        # no   shift, with selection -> jump cursor w.r.t selection
+        # with shift, no   selection -> start new selection, modify selection
+        # with shift, with selection -> modify selection
+
         if mod_shift:
+            if not self.hasSelection():
+                self.selection_start = self.cursor.copy()
+            self.cursor_movement(key)
             self.selection_end = self.cursor.copy()
         else:
+            if self.hasSelection():
+                self.jump_cursor_within_selection(key)
+            else:
+                self.cursor_movement(key)
             self.unselect()
+
+    def jump_cursor_within_selection(self, key):
+        '''
+            Jump cursor with respect to text selection.
+
+            There are 4*2 = 8 different cases, with four different
+            arrow keys and two selection directions.
+
+            Note: The start of the selection does not equal the left end
+                  of the selection in right-to-left selections.
+
+            * LEFT:  Jump to left end of selection.
+            * RIGHT: Jump to right end of selection.
+            * UP:    Jump one line upwards w.r.t. left end of selection.
+            * DOWN:  Jump one line downwards w.r.t. right end of selection.
+        '''
+        selection_start, selection_end = sorted(
+            [self.selection_start, self.selection_end])
+
+        if key == 'left':
+            self.cursor = selection_start.copy()
+        elif key == 'right':
+            self.cursor = selection_end.copy()
+        elif key == 'up':
+            self.cursor = selection_start.copy()
+            self.cursor_movement('up')
+        elif key == 'down':
+            self.cursor = selection_end.copy()
+            self.cursor_movement('down')
 
     def ctrl_cursor(self, key):
         self.log_input("key_escape", repr(key))
@@ -1031,8 +1071,8 @@ class TreeManager(object):
         self.cursor.node = self.selection_end.node
 
     def unselect(self):
-            self.selection_start = self.cursor.copy()
-            self.selection_end = self.cursor.copy()
+        self.selection_start = self.cursor.copy()
+        self.selection_end = self.cursor.copy()
 
     def add_languagebox(self, language):
         if isinstance(language, str):

--- a/lib/eco/treemanager.py
+++ b/lib/eco/treemanager.py
@@ -30,6 +30,7 @@ from export import HTMLPythonSQL, PHPPython, ATerms
 from export.jruby_simple_language import JRubySimpleLanguageExporter
 from export.simple_language import SimpleLanguageExporter
 from export.cpython import CPythonExporter
+from utils import arrow_keys, KEY_UP, KEY_DOWN, KEY_LEFT, KEY_RIGHT
 
 import math
 
@@ -994,6 +995,9 @@ class TreeManager(object):
         self.reparse(repairnode, need_reparse)
         self.changed = True
 
+    def start_new_selection(self):
+        self.selection_start = self.cursor.copy()
+
     def key_shift(self):
         self.log_input("key_shift")
 
@@ -1003,8 +1007,8 @@ class TreeManager(object):
         if node.plain_mode:
             node.plain_mode = False
 
-    def key_cursors(self, key, mod_shift=False):
-        self.log_input("key_cursors", repr(key), str(mod_shift))
+    def key_cursors(self, key, shift=False):
+        self.log_input("key_cursors", arrow_keys[key.key], str(shift))
         self.edit_rightnode = False
 
         # Four possible cases:
@@ -1013,7 +1017,7 @@ class TreeManager(object):
         # with shift, no   selection -> start new selection, modify selection
         # with shift, with selection -> modify selection
 
-        if mod_shift:
+        if shift:
             if not self.hasSelection():
                 self.selection_start = self.cursor.copy()
             self.cursor_movement(key)
@@ -1043,23 +1047,30 @@ class TreeManager(object):
         selection_start, selection_end = sorted(
             [self.selection_start, self.selection_end])
 
-        if key == 'left':
+        if key.left:
             self.cursor = selection_start.copy()
-        elif key == 'right':
+        elif key.right:
             self.cursor = selection_end.copy()
-        elif key == 'up':
+        elif key.up:
             self.cursor = selection_start.copy()
-            self.cursor_movement('up')
-        elif key == 'down':
+            self.cursor_movement(key)
+        elif key.down:
             self.cursor = selection_end.copy()
-            self.cursor_movement('down')
+            self.cursor_movement(key)
 
-    def ctrl_cursor(self, key):
-        self.log_input("key_escape", repr(key))
-        if key == "left":
+    def ctrl_cursor(self, key, shift=False):
+        self.log_input("key_escape", arrow_keys[key.key])
+
+        if shift and not self.hasSelection():
+            self.start_new_selection()
+
+        if key.left:
             self.cursor.jump_left()
-        if key == "right":
+        elif key.right:
             self.cursor.jump_right()
+
+        if shift:
+            self.selection_end = self.cursor.copy()
 
     def doubleclick_select(self):
         self.selection_start = self.cursor.copy()
@@ -1349,13 +1360,13 @@ class TreeManager(object):
     def cursor_movement(self, key):
         cur = self.cursor
 
-        if key == "up":
+        if key.up:
             self.cursor.up(self.lines)
-        elif key == "down":
+        elif key.down:
             self.cursor.down(self.lines)
-        elif key == "left":
+        elif key.left:
             self.cursor.left()
-        elif key == "right":
+        elif key.right:
             self.cursor.right()
         #self.fix_cursor_on_image() #XXX refactor (obsolete after refactoring cursor)
 

--- a/lib/eco/treemanager.py
+++ b/lib/eco/treemanager.py
@@ -126,6 +126,18 @@ class Cursor(object):
             if node.image and not node.plain_mode:
                 self.pos = len(node.symbol.name)
 
+    def jump_to(self, other):
+        """Apply other attributes to self.
+
+        This ensures that the history is not lost.
+        `self.cursor = other.copy()` becomes
+        `self.cursor.jump_to(other)`.
+        """
+
+        self.node = other.node
+        self.pos = other.pos
+        self.line = other.line
+
     def jump_left(self):
         self.node = self.find_previous_visible(self.node)
         self.pos = len(self.node.symbol.name)
@@ -1048,14 +1060,14 @@ class TreeManager(object):
             [self.selection_start, self.selection_end])
 
         if key.left:
-            self.cursor = selection_start.copy()
+            self.cursor.jump_to(selection_start)
         elif key.right:
-            self.cursor = selection_end.copy()
+            self.cursor.jump_to(selection_end)
         elif key.up:
-            self.cursor = selection_start.copy()
+            self.cursor.jump_to(selection_start)
             self.cursor_movement(key)
         elif key.down:
-            self.cursor = selection_end.copy()
+            self.cursor.jump_to(selection_end)
             self.cursor_movement(key)
 
     def ctrl_cursor(self, key, shift=False):

--- a/lib/eco/utils.py
+++ b/lib/eco/utils.py
@@ -1,0 +1,164 @@
+
+import sys
+
+from PyQt4.QtCore import Qt
+
+arrow_keys = {
+    Qt.Key_Up: 'up',
+    Qt.Key_Down: 'down',
+    Qt.Key_Left: 'left',
+    Qt.Key_Right: 'right'
+}
+
+reversed_arrow_keys = {
+    'up': Qt.Key_Up,
+    'down': Qt.Key_Down,
+    'left': Qt.Key_Left,
+    'right': Qt.Key_Right
+}
+
+modifier_keys = set([Qt.Key_Shift, Qt.Key_Alt, Qt.Key_Control, Qt.Key_Meta, Qt.Key_AltGr])
+
+class BaseKeyPress(object):
+    def __init__(self, event):
+        self._event = event
+        self.key = event.key()
+        self.modifiers = event.modifiers()
+        self.native_modifiers = event.nativeModifiers()
+
+    @property
+    def is_arrow(self):
+        return self.key in arrow_keys
+
+    @property
+    def is_modifier(self):
+        return self.key in modifier_keys
+
+    @property
+    def m_shift(self):
+        return self.modifiers == Qt.ShiftModifier
+
+    @property
+    def m_control(self):
+        return self.modifiers == Qt.ControlModifier
+
+    @property
+    def m_alt(self):
+        return self.modifiers == Qt.AltModifier
+
+    @property
+    def has_action_modifier(self):
+        return self.m_control or self.m_alt
+
+    @property
+    def escape(self):
+        return self.key == Qt.Key_Escape
+
+    @property
+    def backspace(self):
+        return self.key == Qt.Key_Backspace
+
+    @property
+    def delete(self):
+        return self.key == Qt.Key_Delete
+
+    @property
+    def home(self):
+        return self.key == Qt.Key_Home
+
+    @property
+    def end(self):
+        return self.key == Qt.Key_End
+
+    @property
+    def left(self):
+        return self.key == Qt.Key_Left
+
+    @property
+    def right(self):
+        return self.key == Qt.Key_Right
+
+    @property
+    def up(self):
+        return self.key == Qt.Key_Up
+
+    @property
+    def down(self):
+        return self.key == Qt.Key_Down
+
+    @property
+    def page_up(self):
+        return self.key == Qt.Key_PageUp
+
+    @property
+    def page_down(self):
+        return self.key == Qt.Key_PageDown
+
+    jump_word = m_control
+
+
+class OSXKeyPress(BaseKeyPress):
+    COMMAND = 0x100 #
+    SHIFT = 0x200
+    CAPSLOCK = 0x400
+    ALT = 0x800
+    META = 0x1000 # labeled `control` on mac keyboards
+
+    @property
+    def m_shift(self):
+        return bool(self.native_modifiers & self.SHIFT)
+
+    @property
+    def m_control(self):
+        return bool(self.native_modifiers & self.COMMAND)
+
+    @property
+    def m_alt(self):
+        return bool(self.native_modifiers & self.ALT)
+
+    @property
+    def home(self):
+        return (
+            BaseKeyPress.home.fget(self)
+            or self.m_control and self.left
+            or self.m_alt and self.up
+        )
+
+    @property
+    def end(self):
+        return (
+            BaseKeyPress.end.fget(self)
+            or self.m_control and self.right
+            or self.m_alt and self.down
+        )
+
+    jump_word = m_alt
+
+
+if sys.platform == 'darwin':
+    KeyPress = OSXKeyPress
+else:
+    KeyPress = BaseKeyPress
+
+
+class MockedKeyPress(KeyPress):
+    def __init__(self, key, modifiers=None):
+        self.key = key
+        self.modifiers = modifiers if modifiers is not None else set()
+
+    @property
+    def m_shift(self):
+        return 'shift' in self.modifiers
+
+    @property
+    def m_control(self):
+        return 'control' in self.modifiers
+
+    @property
+    def m_alt(self):
+        return 'alt' in self.modifiers
+
+KEY_LEFT = MockedKeyPress(reversed_arrow_keys['left'])
+KEY_RIGHT = MockedKeyPress(reversed_arrow_keys['right'])
+KEY_UP = MockedKeyPress(reversed_arrow_keys['up'])
+KEY_DOWN = MockedKeyPress(reversed_arrow_keys['down'])

--- a/lib/eco/utils.py
+++ b/lib/eco/utils.py
@@ -4,17 +4,17 @@ import sys
 from PyQt4.QtCore import Qt
 
 arrow_keys = {
-    Qt.Key_Up: 'up',
-    Qt.Key_Down: 'down',
-    Qt.Key_Left: 'left',
-    Qt.Key_Right: 'right'
+    Qt.Key_Up: "up",
+    Qt.Key_Down: "down",
+    Qt.Key_Left: "left",
+    Qt.Key_Right: "right"
 }
 
 reversed_arrow_keys = {
-    'up': Qt.Key_Up,
-    'down': Qt.Key_Down,
-    'left': Qt.Key_Left,
-    'right': Qt.Key_Right
+    "up": Qt.Key_Up,
+    "down": Qt.Key_Down,
+    "left": Qt.Key_Left,
+    "right": Qt.Key_Right
 }
 
 modifier_keys = set([Qt.Key_Shift, Qt.Key_Alt, Qt.Key_Control, Qt.Key_Meta, Qt.Key_AltGr])
@@ -135,7 +135,7 @@ class OSXKeyPress(BaseKeyPress):
     jump_word = m_alt
 
 
-if sys.platform == 'darwin':
+if sys.platform == "darwin":
     KeyPress = OSXKeyPress
 else:
     KeyPress = BaseKeyPress
@@ -148,17 +148,17 @@ class MockedKeyPress(KeyPress):
 
     @property
     def m_shift(self):
-        return 'shift' in self.modifiers
+        return "shift" in self.modifiers
 
     @property
     def m_control(self):
-        return 'control' in self.modifiers
+        return "control" in self.modifiers
 
     @property
     def m_alt(self):
-        return 'alt' in self.modifiers
+        return "alt" in self.modifiers
 
-KEY_LEFT = MockedKeyPress(reversed_arrow_keys['left'])
-KEY_RIGHT = MockedKeyPress(reversed_arrow_keys['right'])
-KEY_UP = MockedKeyPress(reversed_arrow_keys['up'])
-KEY_DOWN = MockedKeyPress(reversed_arrow_keys['down'])
+KEY_LEFT = MockedKeyPress(reversed_arrow_keys["left"])
+KEY_RIGHT = MockedKeyPress(reversed_arrow_keys["right"])
+KEY_UP = MockedKeyPress(reversed_arrow_keys["up"])
+KEY_DOWN = MockedKeyPress(reversed_arrow_keys["down"])


### PR DESCRIPTION
This PR adds to things:

A new `KeyPress` class, that wraps key presses which also supports os x.

Modification of the API for `key_cursors` and `control_cursors`. They now take a `KeyPress` object, instead of a string.

There is still some work, but I wanted to have this code as a discussion base.
