### PR TITLE
Fix export of Python+HTML+SQL.

### DIFF
--- a/lib/eco/eco.py
+++ b/lib/eco/eco.py
@@ -1221,7 +1221,7 @@ class Window(QtGui.QMainWindow):
         self.ui.menuChange_language_box.setEnabled(enabled)
         self.ui.actionPreview.setEnabled(enabled)
         self.ui.actionInput_log.setEnabled(enabled)
-        
+
         if enabled == False:
             self.ui.actionProfile.setEnabled(enabled)
             self.ui.actionStateGraph.setEnabled(enabled)

--- a/lib/eco/treemanager.py
+++ b/lib/eco/treemanager.py
@@ -1472,6 +1472,8 @@ class TreeManager(object):
             self.export_unipycation(path)
         elif lang == "HTML + Python + SQL":
             self.export_html_python_sql(path)
+        elif lang == "Python + HTML + SQL":
+            self.export_html_python_sql(path)
         elif lang == "PHP + Python" or lang == "PHP":
             return self.export_php_python(path, run, source=source)
         elif lang == "Python 2.7.5":
@@ -1515,7 +1517,6 @@ class TreeManager(object):
             f = tempfile.mkstemp()
             os.write(f[0],"".join(output))
             os.close(f[0])
-            
             settings = QSettings("softdev", "Eco")
             unipath = str(settings.value("env_unipycation", "").toString())
             if unipath:


### PR DESCRIPTION
Files using a `Python + HTML + SQL` grammar have been exported as text, because the if/else block in the `treemanager` which deals with exports only recognised `HTML + Python + SQL`. 

This PR fixes that, however it still won't be possible to run a `Python + HTML + SQL` file. I'm not sure whether that is intended behaviour or not.

/cc @jaheba 
