### PR TITLE
Refactored Cursor to have reference to tm.lines

### DIFF
--- a/lib/eco/export/cpython.py
+++ b/lib/eco/export/cpython.py
@@ -79,7 +79,7 @@ class CPythonExporter(object):
                 # Move cursor to correct line and character
                 msg = ('%s: called %s times ran at %ss / call' % (func, ncalls, tokens[2]))
                 temp_cursor.line = lineno - 1
-                temp_cursor.move_to_x(0, self.tm.lines)
+                temp_cursor.move_to_x(0)
                 node = temp_cursor.find_next_visible(temp_cursor.node)
                 if node.lookup == "<ws>":
                     node = node.next_term

--- a/lib/eco/export/jruby.py
+++ b/lib/eco/export/jruby.py
@@ -208,7 +208,7 @@ class JRubyExporter(object):
         try:
             temp_cursor = self.tm.cursor.copy()
             temp_cursor.line = lineno - 1
-            temp_cursor.move_to_x(0, self.tm.lines)
+            temp_cursor.move_to_x(0)
             node = temp_cursor.find_next_visible(temp_cursor.node)
             while node.lookup == '<ws>' or node.symbol.name != text:
                 node = node.next_term

--- a/lib/eco/export/jruby_simple_language.py
+++ b/lib/eco/export/jruby_simple_language.py
@@ -168,7 +168,7 @@ class JRubySimpleLanguageExporter(object):
         # Remove old annotations
         for lineno in xrange(len(self.tm.lines)):
             temp_cursor.line = lineno
-            temp_cursor.move_to_x(0, self.tm.lines)
+            temp_cursor.move_to_x(0)
             node = temp_cursor.find_next_visible(temp_cursor.node)
             if node.lookup == "<ws>":
                 node = node.next_term
@@ -196,7 +196,7 @@ class JRubySimpleLanguageExporter(object):
                     lineno = plain_lines.index(line.split(":")[1][1:]) + 1
                     msg = ('Line %s ran %s times' % (lineno, ncalls))
                     temp_cursor.line = lineno - 1
-                    temp_cursor.move_to_x(0, self.tm.lines)
+                    temp_cursor.move_to_x(0)
                     node = temp_cursor.find_next_visible(temp_cursor.node)
                     if node.lookup == "<ws>":
                         node = node.next_term

--- a/lib/eco/export/simple_language.py
+++ b/lib/eco/export/simple_language.py
@@ -86,7 +86,7 @@ class SimpleLanguageExporter(object):
         # Remove old annotations
         for lineno in xrange(len(self.tm.lines)):
             temp_cursor.line = lineno
-            temp_cursor.move_to_x(0, self.tm.lines)
+            temp_cursor.move_to_x(0)
             node = temp_cursor.find_next_visible(temp_cursor.node)
             if node.lookup == "<ws>":
                 node = node.next_term
@@ -109,7 +109,7 @@ class SimpleLanguageExporter(object):
                 lineno = int(tokens[2][:-1])
                 msg = ('Line %s ran %s times' % (lineno, ncalls))
                 temp_cursor.line = lineno - 1
-                temp_cursor.move_to_x(0, self.tm.lines)
+                temp_cursor.move_to_x(0)
                 node = temp_cursor.find_next_visible(temp_cursor.node)
                 if node.lookup == "<ws>":
                     node = node.next_term

--- a/lib/eco/nodeeditor.py
+++ b/lib/eco/nodeeditor.py
@@ -27,7 +27,7 @@ from PyQt4.QtGui import *
 BODY_FONT = "Monospace"
 BODY_FONT_SIZE = 9
 
-from treemanager import TreeManager, Cursor
+from treemanager import TreeManager
 from grammars.grammars import submenu_langs as languages, lang_dict
 from grammar_parser.gparser import Terminal, MagicTerminal, IndentationTerminal, Nonterminal
 from grammar_parser.bootstrap import ListNode, AstNode
@@ -692,10 +692,10 @@ class NodeEditor(QFrame):
 
         self.tm.cursor.line = line
         cursor_x = int(round(float(x) / self.fontwt))
-        self.tm.cursor.move_to_x(cursor_x, self.tm.lines)
+        self.tm.cursor.move_to_x(cursor_x)
 
         self.tm.input_log.append("self.cursor.line = %s" % str(line))
-        self.tm.log_input("cursor.move_to_x", str(cursor_x), "self.lines")
+        self.tm.log_input("cursor.move_to_x", str(cursor_x))
 
         if mouse_y > y or self.tm.cursor.get_x() != cursor_x:
             return False

--- a/lib/eco/overlay.py
+++ b/lib/eco/overlay.py
@@ -109,16 +109,16 @@ class Overlay(QWidget):
                                            'max_x': 0,
                                            'is_mega': False, }
         temp_cursor = self.tm.cursor.copy()  # Save cursor to restore later.
-        self.tm.cursor.line = 0  # Start at beginning of syntax tree.
-        self.tm.cursor.move_to_x(0)
-        while not (isinstance(self.tm.cursor.node, EOS) or
-                   isinstance(self.tm.cursor.node.next_term, EOS)):
-            if self.tm.cursor.node.symbol.name in self._railroad_data.keys():
-                method = self.tm.cursor.node.symbol.name
-                saved_x = self.tm.cursor.get_x()
-                self.tm.key_end()
-                location = (self.tm.cursor.line + 1, self.tm.cursor.get_x())
-                self.tm.cursor.move_to_x(saved_x)
+        temp_cursor.line = 0  # Start at beginning of syntax tree.
+        temp_cursor.move_to_x(0)
+        while not (isinstance(temp_cursor.node, EOS) or
+                   isinstance(temp_cursor.node.next_term, EOS)):
+            if temp_cursor.node.symbol.name in self._railroad_data.keys():
+                method = temp_cursor.node.symbol.name
+                saved_x = temp_cursor.get_x()
+                temp_cursor.end()
+                location = (temp_cursor.line + 1, temp_cursor.get_x())
+                temp_cursor.move_to_x(saved_x)
                 # Assume the first occurrence of the method is its definition.
                 if railroad_data[method]['definition'] is None:
                     railroad_data[method]['definition'] = location
@@ -129,8 +129,7 @@ class Overlay(QWidget):
                 railroad_data[method]['max_x'] = max_x
                 if self._railroad_data[method]:
                     railroad_data[method]['is_mega'] = True
-            self.tm.cursor.jump_right()
-        self.tm.cursor = temp_cursor # Restore cursor.
+            temp_cursor.jump_right()
 
         # Compute lines (and their colours).
         painter = QPainter()

--- a/lib/eco/overlay.py
+++ b/lib/eco/overlay.py
@@ -110,7 +110,7 @@ class Overlay(QWidget):
                                            'is_mega': False, }
         temp_cursor = self.tm.cursor.copy()  # Save cursor to restore later.
         self.tm.cursor.line = 0  # Start at beginning of syntax tree.
-        self.tm.cursor.move_to_x(0, self.tm.lines)
+        self.tm.cursor.move_to_x(0)
         while not (isinstance(self.tm.cursor.node, EOS) or
                    isinstance(self.tm.cursor.node.next_term, EOS)):
             if self.tm.cursor.node.symbol.name in self._railroad_data.keys():
@@ -118,7 +118,7 @@ class Overlay(QWidget):
                 saved_x = self.tm.cursor.get_x()
                 self.tm.key_end()
                 location = (self.tm.cursor.line + 1, self.tm.cursor.get_x())
-                self.tm.cursor.move_to_x(saved_x, self.tm.lines)
+                self.tm.cursor.move_to_x(saved_x)
                 # Assume the first occurrence of the method is its definition.
                 if railroad_data[method]['definition'] is None:
                     railroad_data[method]['definition'] = location

--- a/lib/eco/test/test_eco.py
+++ b/lib/eco/test/test_eco.py
@@ -2471,11 +2471,11 @@ self.key_cursors(KEY_LEFT, False)
 self.key_cursors(KEY_LEFT, False)
 # mousePressEvent
 self.cursor.line = 1
-self.cursor.move_to_x(11, self.lines)
+self.cursor.move_to_x(11)
 self.selection_start = self.cursor.copy()
 self.selection_end = self.cursor.copy()
 self.cursor.line = 1
-self.cursor.move_to_x(8, self.lines)
+self.cursor.move_to_x(8)
 self.selection_end = self.cursor.copy()
 self.cursor.line = 2
 self.key_normal('f')
@@ -2483,7 +2483,7 @@ self.key_normal('o')
 self.key_normal('o')
 # mousePressEvent
 self.cursor.line = 2
-self.cursor.move_to_x(16, self.lines)
+self.cursor.move_to_x(16)
 self.selection_start = self.cursor.copy()
 self.selection_end = self.cursor.copy()
 self.key_backspace()


### PR DESCRIPTION
This refactoring of `Cursor` makes its methods (`up`, `down`, `move_to_x`) independent of `treemanager.lines` due to `Cursor` now having a reference to `lines`. Also moved `end` and `home` to `Cursor` class.
