### PR TITLE
Jruby fix viewport error

### DIFF
--- a/lib/eco/gui/settings.ui
+++ b/lib/eco/gui/settings.ui
@@ -348,7 +348,7 @@
         <item>
          <widget class="QGroupBox" name="groupBox_10">
           <property name="title">
-           <string>GraalVM Polymorphic Inline Cache</string>
+           <string>GraalVM polymorphic inline cache</string>
           </property>
           <layout class="QGridLayout" name="gridLayout">
            <item row="0" column="0">

--- a/lib/eco/nodeeditor.py
+++ b/lib/eco/nodeeditor.py
@@ -257,6 +257,9 @@ class NodeEditor(QFrame):
         current_width = self.parentWidget().geometry().width() / self.fontwt
         self.scroll_width = max(0, max_width - current_width)
 
+        railroad_annotations = self.tm.get_all_annotations_with_hint(Railroad)
+        self.overlay.add_railroad_data(railroad_annotations)
+
         self.emit(SIGNAL("painted()"))
 
     # paint lines using new line manager
@@ -280,7 +283,7 @@ class NodeEditor(QFrame):
         line = internal_line
         node = self.tm.lines[line].node
 
-        self.paint_nodes(paint, node, x, y, line, max_y)
+        _, _, self.end_line = self.paint_nodes(paint, node, x, y, line, max_y)
 
 
     #XXX if starting node is inside language box, init lbox with amout of languge boxes
@@ -409,13 +412,10 @@ class NodeEditor(QFrame):
             #y += dy
             self.lines[line].height = max(self.lines[line].height, dy)
 
-            # Draw footnotes and add data to overlay.
+            # Draw footnotes and add heatmap data to overlay.
             annotes = [annote.annotation for annote in node.get_annotations_with_hint(Heatmap)]
             for annote in annotes:
                 self.overlay.add_heatmap_datum(line + 1, annote)
-            annotes = [annote.annotation for annote in node.get_annotations_with_hint(Railroad)]
-            for annote in annotes:
-                self.overlay.add_railroad_datum(annote)
             if self.show_tool_visualisations:
                 # Draw footnotes.
                 infofont = QApplication.instance().tool_info_font

--- a/lib/eco/treemanager.py
+++ b/lib/eco/treemanager.py
@@ -1116,6 +1116,24 @@ class TreeManager(object):
         self.cursor.line = len(self.lines) - 1
         self.selection_end = self.cursor.copy()
 
+    def get_all_annotations_with_hint(self, hint):
+        """Return all annotations (optionally of a specific type).
+        Call sparingly as this runs over the whole tree.
+        """
+        node = self.lines[0].node
+        annotations = list()
+        while True:
+            for annote in node.get_annotations_with_hint(hint):
+                annotations.append(annote.annotation)
+            node = node.next_term
+            if isinstance(node, EOS):
+                lbnode = self.get_languagebox(node)
+                if lbnode:
+                    node = lbnode
+                else:
+                    break
+        return annotations
+
     def unselect(self):
         self.selection_start = self.cursor.copy()
         self.selection_end = self.cursor.copy()


### PR DESCRIPTION
This also fixes a typo in Settings.

The main fix is this: previously when a railroad line (from the JRuby morphism demo) fell outside of the viewport, the whole set of lines for that method would disappear. This is how the demo looked before the bug fix (on the current master branch):

[Before bug fix video](https://youtu.be/nU5pzSeyFZw)

This is how the morphism demo looks with this bug fix: 

[After bug fix video](https://youtu.be/83Wn_0YMQJg)
