### PR TITLE
Add JRuby+JavaScript grammar option. 

### DIFF
--- a/lib/eco/eco.py
+++ b/lib/eco/eco.py
@@ -311,6 +311,7 @@ class SettingsView(QtGui.QMainWindow):
         self.connect(self.ui.btjruby, SIGNAL("clicked()"), self.choose_file)
         self.connect(self.ui.btgraalvm, SIGNAL("clicked()"), self.choose_file)
         self.connect(self.ui.btsljar, SIGNAL("clicked()"), self.choose_file)
+        self.connect(self.ui.btjsjar, SIGNAL("clicked()"), self.choose_file)
         self.connect(self.ui.bttrufflejar, SIGNAL("clicked()"), self.choose_file)
 
         self.foreground = None
@@ -342,6 +343,8 @@ class SettingsView(QtGui.QMainWindow):
                 self.ui.env_graalvm.setText(filename)
             elif self.sender() is self.ui.btsljar:
                 self.ui.env_sl_jar.setText(filename)
+            elif self.sender() is self.ui.btjsjar:
+                self.ui.env_js_jar.setText(filename)
             elif self.sender() is self.ui.bttrufflejar:
                 self.ui.env_truffle_jar.setText(filename)
 
@@ -391,6 +394,7 @@ class SettingsView(QtGui.QMainWindow):
         self.ui.env_jruby.setText(settings.value("env_jruby", "").toString())
         self.ui.env_graalvm.setText(settings.value("env_graalvm", "").toString())
         self.ui.env_sl_jar.setText(settings.value("env_sl_jar", "").toString())
+        self.ui.env_js_jar.setText(settings.value("env_js_jar", "").toString())
         self.ui.env_truffle_jar.setText(settings.value("env_truffle_jar", "").toString())
 
     def saveSettings(self):
@@ -423,6 +427,7 @@ class SettingsView(QtGui.QMainWindow):
         settings.setValue("env_jruby", self.ui.env_jruby.text())
         settings.setValue("env_graalvm", self.ui.env_graalvm.text())
         settings.setValue("env_sl_jar", self.ui.env_sl_jar.text())
+        settings.setValue("env_js_jar", self.ui.env_js_jar.text())
         settings.setValue("env_truffle_jar", self.ui.env_truffle_jar.text())
 
     def accept(self):

--- a/lib/eco/export/jruby_javascript.py
+++ b/lib/eco/export/jruby_javascript.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2015--2016 King's College London
+# Created by the Software Development Team <http://soft-dev.org/>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+import tempfile
+import subprocess
+
+from incparser.annotation import Annotation, ToolTip, Heatmap
+
+from PyQt4.QtCore import QSettings
+from incparser.astree import EOS
+from grammar_parser.gparser import MagicTerminal, IndentationTerminal
+
+
+class JRubyCoverageCounterMsg(Annotation):
+    def __init__(self, annotation):
+        self._hints = [ToolTip()]
+        super(JRubyCoverageCounterMsg, self).__init__(annotation)
+
+    def get_hints(self):
+        return self._hints
+
+
+class JRubyCoverageCounterVal(Annotation):
+    def __init__(self, annotation):
+        self._hints = [Heatmap()]
+        super(JRubyCoverageCounterVal, self).__init__(annotation)
+
+    def get_hints(self):
+        return self._hints
+
+
+class JRubyJavaScriptExporter(object):
+    def __init__(self, tm):
+        self.tm = tm  # TreeManager object.
+        self.js_functions = dict()
+        self._js_output = list()
+        self._wrappers = list()
+        self._output = list()
+        self._js_functions = list()
+
+    def export(self, path=None, run=False):
+        if path is not None:
+            self._export_as_text(path)
+            return
+        if run:
+            return self._run()
+
+    def _language_box(self, name, node):
+        if name == "<Ruby + JavaScript>":
+            self._walk_rb(node)
+        elif name == "<JavaScript>":
+            self._walk_js(node)
+
+    def _walk_js(self, node):
+        while True:
+            node = node.next_term
+            sym = node.symbol
+            if isinstance(node, EOS):
+                break
+            if isinstance(sym, MagicTerminal):
+                self._language_box(sym.name, node.symbol.ast.children[0])
+            elif isinstance(sym, IndentationTerminal):
+                self._js_output.append(sym)
+            elif sym.name == "function":
+                self._js_functions.append(node.next_term.next_term.symbol.name)
+                self._js_output.append(sym.name)
+            elif sym.name == "\r":
+                self._js_output.append("\n")
+            else:
+                self._js_output.append(sym.name)
+
+    def _walk_rb(self, node):
+        while True:
+            node = node.next_term
+            sym = node.symbol
+            if isinstance(node, EOS):
+                break
+            if isinstance(sym, MagicTerminal):
+                self._language_box(sym.name, node.symbol.ast.children[0])
+            elif isinstance(sym, IndentationTerminal):
+                self._output.append(sym)
+            elif sym.name == "\r":
+                self._output.append("\n")
+            else:
+                self._output.append(sym.name)
+
+    def _apply_template(self, name):
+        return "Truffle::Interop.import_method(:%s)" % name
+
+    def _export_as_text(self, path):
+        node = self.tm.lines[0].node # first node
+        self._walk_rb(node)
+        for func in self._js_functions:
+            self._wrappers.append(self._apply_template(func))
+        output = "Truffle::Interop.eval('application/x-javascript', %{\n"
+        output += "".join(self._js_output)
+        output += "})\n\n"
+        output += "\n".join(self._wrappers)
+        output += "\n\n"
+        rb_code = "".join(self._output)
+        output += rb_code
+        with open(path, "w") as fp:
+            fp.write("".join(output))
+
+    def _run(self):
+        f = tempfile.mkstemp(suffix=".rb")
+        settings = QSettings('softdev', 'Eco')
+        graalvm_bin = str(settings.value('env_graalvm', '').toString())
+        jruby_bin = str(settings.value('env_jruby', '').toString())
+        js_jar = str(settings.value('env_js_jar', '').toString())
+        truffle_jar = str(settings.value('env_truffle_jar', '').toString())
+        jars = js_jar + ':' + truffle_jar
+
+        self._export_as_text(f[1])
+        if graalvm_bin:
+            return subprocess.Popen([jruby_bin, "-X+T",
+                                     "-J-classpath", jars, f[1]],
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.STDOUT,
+                                    bufsize=0,
+                                    env={'JAVACMD':graalvm_bin})
+        else:
+            return subprocess.Popen([jruby_bin, "-X+T",
+                                     "-J-classpath", jars, f[1]],
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.STDOUT,
+                                    bufsize=0)

--- a/lib/eco/grammars/grammars.py
+++ b/lib/eco/grammars/grammars.py
@@ -177,9 +177,12 @@ ruby = EcoFile("Ruby", "grammars/ruby.eco", "Ruby")
 rubysl = EcoFile("Ruby + SimpleLanguage", "grammars/ruby.eco", "Ruby")
 rubysl.add_alternative("top_stmt", simplelang)
 
-languages = [calc, java, javasqlchemical, java_expr, php, phppython, python, pythonhtmlsql, pythonprolog, pythonphp, prolog, sql, sql_ref_java, html, htmlpythonsql, eco, scoping, img, chemical, eco_grammar, python_expr, ipython, pythonipython, simplelang, ruby, rubysl, javascript]
-newfile_langs = [java, javasqlchemical, php, phppython, python, pythonhtmlsql, pythonprolog, prolog, sql, html, htmlpythonsql, pythonipython, calc, ruby, simplelang, rubysl, javascript]
-submenu_langs = [java, javasqlchemical, java_expr, php, phppython, python, pythonhtmlsql, pythonprolog, pythonphp, python_expr, prolog, sql, sql_ref_java, html, htmlpythonsql, img, chemical, ipython, ruby, simplelang, rubysl]
+rubyjs = EcoFile("Ruby + JavaScript", "grammars/ruby.eco", "Ruby")
+rubyjs.add_alternative("top_stmt", simplelang)
+
+languages = [calc, java, javasqlchemical, java_expr, php, phppython, python, pythonhtmlsql, pythonprolog, pythonphp, prolog, sql, sql_ref_java, html, htmlpythonsql, eco, scoping, img, chemical, eco_grammar, python_expr, ipython, pythonipython, simplelang, ruby, rubysl, rubyjs, javascript]
+newfile_langs = [java, javasqlchemical, php, phppython, python, pythonhtmlsql, pythonprolog, prolog, sql, html, htmlpythonsql, pythonipython, calc, ruby, simplelang, rubysl, rubyjs, javascript]
+submenu_langs = [java, javasqlchemical, java_expr, php, phppython, python, pythonhtmlsql, pythonprolog, pythonphp, python_expr, prolog, sql, sql_ref_java, html, htmlpythonsql, img, chemical, ipython, ruby, simplelang, rubysl, rubyjs]
 
 lang_dict = {}
 for l in languages:

--- a/lib/eco/gui/settings.ui
+++ b/lib/eco/gui/settings.ui
@@ -609,7 +609,7 @@
         <item>
          <widget class="QGroupBox" name="groupBox_10">
           <property name="title">
-           <string>SimpleLanguage .jar file</string>
+           <string>Truffle SimpleLanguage .jar file</string>
           </property>
           <layout class="QFormLayout" name="formLayout_11">
            <item row="0" column="1">
@@ -648,11 +648,50 @@
         <item>
          <widget class="QGroupBox" name="groupBox_10">
           <property name="title">
-           <string>Truffle API .jar file</string>
+           <string>Truffle JavaScript .jar file</string>
           </property>
           <layout class="QFormLayout" name="formLayout_12">
            <item row="0" column="1">
             <layout class="QHBoxLayout" name="horizontalLayout_9">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLineEdit" name="env_js_jar"/>
+             </item>
+             <item>
+              <widget class="QToolButton" name="btjsjar">
+               <property name="text">
+                <string>...</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_17">
+             <property name="text">
+              <string>Binary</string>
+             </property>
+             <property name="buddy">
+              <cstring>env_js_jar</cstring>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="groupBox_11">
+          <property name="title">
+           <string>Truffle API .jar file</string>
+          </property>
+          <layout class="QFormLayout" name="formLayout_13">
+           <item row="0" column="1">
+            <layout class="QHBoxLayout" name="horizontalLayout_10">
              <property name="leftMargin">
               <number>0</number>
              </property>
@@ -672,12 +711,12 @@
             </layout>
            </item>
            <item row="0" column="0">
-            <widget class="QLabel" name="label_17">
+            <widget class="QLabel" name="label_18">
              <property name="text">
               <string>Binary</string>
              </property>
              <property name="buddy">
-              <cstring>env_sl_jar</cstring>
+              <cstring>env_truffle_jar</cstring>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
Includes exporter and option in Settings dialog to set the path to a Truffle / JS JAR file.

JRuby SL interop now works again, and JRuby now has facilities forJavaScript interop. This PR adds a new grammar option for Ruby+JavaScript to Eco. 

The screenshot below shows the Ruby+SimpleLanguage interop working correctly. The JRubry repo contains examples of how exported interop code should look. This is the SL example:

https://github.com/jruby/jruby/blob/9cd2ccc43470771a563048f792c4b977c7b43344/test/truffle/integration/sl/inline-exported.rb

This is the JS example:

https://github.com/jruby/jruby/blob/9cd2ccc43470771a563048f792c4b977c7b43344/test/truffle/integration/js/inline-exported.rb

![jruby_sl_interop](https://cloud.githubusercontent.com/assets/97674/15391391/d80d878e-1db8-11e6-823e-4ab17d2fa746.png)
