### PR TITLE
Removed unused class LineNumbers from eco.py

### DIFF
--- a/lib/eco/eco.py
+++ b/lib/eco/eco.py
@@ -96,49 +96,6 @@ class GlobalFont(object):
         self.fontwt = self.fontm.width(" "*99)/99.0
         self.fontd = self.fontm.descent()
 
-class LineNumbers(QFrame):
-    def __init__(self, parent=None):
-        QtGui.QFrame.__init__(self, parent)
-
-        family = settings.value("font-family").toString()
-        size = settings.value("font-size").toInt()[0]
-        self.font = QtGui.QFont(family, size)
-        self.fontm = QtGui.QFontMetrics(self.font)
-        self.fontht = self.fontm.height() + 3
-        self.fontwt = self.fontm.width(" ")
-
-        self.info = []
-
-    def paintEvent(self, event):
-        paint = QtGui.QPainter()
-        paint.begin(self)
-        paint.setPen(QColor("grey"))
-        paint.setFont(self.font)
-
-        scrollbar_height = self.window().ui.scrollArea.horizontalScrollBar().geometry().height()
-
-        for y, line, indent in self.info:
-            if self.fontht + y*self.fontht > self.geometry().height() - scrollbar_height:
-                break
-            text = str(line)# + "|" + str(indent)
-            x = self.geometry().width() - len(text) * self.fontwt - self.fontwt
-            paint.drawText(QtCore.QPointF(x, self.fontht + y*self.fontht), text +":")
-
-        paint.end()
-        self.info = []
-
-    def getMaxWidth(self):
-        max_width = 0
-        for _, line, _ in self.info:
-            max_width = max(max_width, self.fontm.width(str(line)+":"))
-        return max_width
-
-    def change_font(self, font):
-        self.font = font[0]
-        self.fontm = QtGui.QFontMetrics(self.font)
-        self.fontht = self.fontm.height() + 3
-        self.fontwt = self.fontm.width(" ")
-
 class ScopeScrollArea(QtGui.QAbstractScrollArea):
     def setWidgetResizable(self, b):
         self.resizable = True

--- a/lib/eco/eco.py
+++ b/lib/eco/eco.py
@@ -96,34 +96,6 @@ class GlobalFont(object):
         self.fontwt = self.fontm.width(" "*99)/99.0
         self.fontd = self.fontm.descent()
 
-class ScopeScrollArea(QtGui.QAbstractScrollArea):
-    def setWidgetResizable(self, b):
-        self.resizable = True
-
-    def setAlignment(self, align):
-        self.alignment = align
-
-    def setWidget(self, widget):
-        self.widget = widget
-        self.viewport().setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
-        self.widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
-        anotherbox = QtGui.QVBoxLayout(self.viewport())
-        anotherbox.addWidget(widget)
-        anotherbox.setSpacing(0)
-        anotherbox.setContentsMargins(3,0,0,0)
-
-    def incHSlider(self):
-        self.horizontalScrollBar().setSliderPosition(self.horizontalScrollBar().sliderPosition() + self.horizontalScrollBar().singleStep())
-
-    def decHSlider(self):
-        self.horizontalScrollBar().setSliderPosition(self.horizontalScrollBar().sliderPosition() - self.horizontalScrollBar().singleStep())
-
-    def incVSlider(self):
-        self.verticalScrollBar().setSliderPosition(self.verticalScrollBar().sliderPosition() + self.verticalScrollBar().singleStep())
-
-    def decVSlider(self):
-        self.verticalScrollBar().setSliderPosition(self.verticalScrollBar().sliderPosition() - self.verticalScrollBar().singleStep())
-
 class ParseView(QtGui.QMainWindow):
     def __init__(self, window):
         QtGui.QMainWindow.__init__(self, window)


### PR DESCRIPTION
The LineNumbers class that is actually used is in editortab.py, so I deleted the unused one.
