### PR TITLE
Fixed bug in cursor movement

### DIFF
--- a/lib/eco/test/test_eco.py
+++ b/lib/eco/test/test_eco.py
@@ -2251,6 +2251,29 @@ class Test_Undo(Test_Python):
         self.treemanager.key_ctrl_z()
         self.text_compare(prog)
 
+    def test_undo_random_insertdeleteundo_bug3(self):
+        self.reset()
+
+        self.treemanager.import_file("""class C:
+    x = 5
+""")
+        assert self.parser.last_status == True
+
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 0)
+        self.move(RIGHT, 1)
+        self.treemanager.key_normal('\r')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 0)
+        self.move(RIGHT, 0)
+        self.treemanager.key_normal('\r')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 0)
+        self.move(RIGHT, 2)
+        self.treemanager.key_delete()
+
+        assert self.parser.last_status == False
+
     def random_insert_delete_undo(self, program):
         import random
         self.reset()

--- a/lib/eco/treemanager.py
+++ b/lib/eco/treemanager.py
@@ -117,6 +117,8 @@ class Cursor(object):
         if not node is self.node:
             self.node = node
             self.pos = 0
+            if node.symbol.name == "\r":
+                self.line += 1
         if self.pos < len(self.node.symbol.name):
             self.pos += 1
         else:


### PR DESCRIPTION
This bug was found in one of the fuzzy testers. It had to do with the cursor movement and that the line number wasn't updated properly when using `cursor_right` when at the beginning of the file and the first line was empty.

Fixes #144 
