### PR TITLE
JRuby HUD. Includes callgraph, eval() strings and argument types.

### DIFF
--- a/lib/eco/gui/gui.ui
+++ b/lib/eco/gui/gui.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>920</width>
+    <width>1069</width>
     <height>737</height>
    </rect>
   </property>
@@ -24,8 +24,8 @@
     <normaloff>gui/eco.png</normaloff>gui/eco.png</iconset>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QVBoxLayout" name="verticalLayout_4">
-    <item>
+   <layout class="QGridLayout" name="gridLayout">
+    <item row="0" column="0">
      <widget class="QTabWidget" name="tabWidget">
       <property name="currentIndex">
        <number>-1</number>
@@ -45,8 +45,8 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>920</width>
-     <height>23</height>
+     <width>1069</width>
+     <height>26</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -206,13 +206,51 @@
     </size>
    </property>
    <property name="windowTitle">
-    <string>Parsing Status</string>
+    <string>Parsing and HUD</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>2</number>
    </attribute>
    <widget class="QWidget" name="dockWidgetContents_2">
-    <layout class="QHBoxLayout" name="horizontalLayout_5">
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <item>
+      <widget class="QRadioButton" name="hud_off_button">
+       <property name="text">
+        <string>No HUD</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="hud_callgraph_button">
+       <property name="text">
+        <string>Callgraph</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="hud_types_button">
+       <property name="text">
+        <string>Types</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="hud_eval_button">
+       <property name="text">
+        <string>eval() strings</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="hud_heat_map_button">
+       <property name="text">
+        <string>Heat map</string>
+       </property>
+      </widget>
+     </item>
      <item>
       <widget class="QTreeWidget" name="treeWidget">
        <property name="alternatingRowColors">
@@ -237,6 +275,12 @@
         <bool>false</bool>
        </property>
        <attribute name="headerVisible">
+        <bool>false</bool>
+       </attribute>
+       <attribute name="headerHighlightSections">
+        <bool>false</bool>
+       </attribute>
+       <attribute name="headerShowSortIndicator" stdset="0">
         <bool>false</bool>
        </attribute>
        <column>
@@ -685,7 +729,7 @@
    </property>
    <property name="icon">
     <iconset>
-      <normaloff>gui/bug.png</normaloff>bug.png</iconset>
+     <normaloff>gui/bug.png</normaloff>gui/bug.png</iconset>
    </property>
    <property name="text">
     <string>Run with debugger</string>

--- a/lib/eco/incparser/annotation.py
+++ b/lib/eco/incparser/annotation.py
@@ -43,6 +43,18 @@ class ToolTip(Hint):
     pass
 
 
+class Eval(Hint):
+    """Annotations displayed when the HUD eval() strings button is down.
+    """
+    pass
+
+
+class Types(Hint):
+    """Annotations displayed when the HUD types button is down.
+    """
+    pass
+
+
 class Annotation(object):
     """An Annotation is a piece of information related to a node.
     Annotations are used to instrument the AST with runtime information about
@@ -60,6 +72,15 @@ class Annotation(object):
     @annotation.setter
     def annotation(self, annotation):
         self._annotation = annotation
+
+    @abc.abstractmethod
+    def has_hint(self, klass):
+        """Returns True if annotation contains the given hint, else False.
+        Eco will use these hints to determine how annotations of this type
+        will be visualised in the editor.
+        """
+        msg = "has_hint(klass) must be implemented in subclasses of Annotation."
+        raise NotImplementedError(msg)
 
     @abc.abstractmethod
     def get_hints(self):

--- a/lib/eco/nodeeditor.py
+++ b/lib/eco/nodeeditor.py
@@ -35,7 +35,7 @@ from incparser.astree import BOS, EOS
 from jsonmanager import JsonManager
 from utils import KeyPress
 from overlay import Overlay
-from incparser.annotation import Footnote, Heatmap, Railroad, ToolTip
+from incparser.annotation import Eval, Footnote, Heatmap, Railroad, ToolTip, Types
 
 import syntaxhighlighter
 import editor
@@ -86,6 +86,42 @@ class NodeEditor(QFrame):
         # Set True if Eco should be running profiler and other tools,
         # continuously in the background.
         self.run_background_tools = False
+
+        # Show / don't show HUD visualisations.
+        self.hud_callgraph = False
+        self.hud_eval = False
+        self.hud_heat_map = False
+        self.hud_types = False
+
+    def hud_show_callgraph(self):
+        self.hud_callgraph = True
+        self.hud_eval = False
+        self.hud_heat_map = False
+        self.hud_types = False
+
+    def hud_show_eval(self):
+        self.hud_callgraph = False
+        self.hud_eval = True
+        self.hud_heat_map = False
+        self.hud_types = False
+
+    def hud_show_types(self):
+        self.hud_callgraph = False
+        self.hud_eval = False
+        self.hud_heat_map = False
+        self.hud_types = True
+
+    def hud_show_heat_map(self):
+        self.hud_callgraph = False
+        self.hud_eval = False
+        self.hud_heat_map = True
+        self.hud_types = False
+
+    def hud_off(self):
+        self.hud_callgraph = False
+        self.hud_eval = False
+        self.hud_heat_map = False
+        self.hud_types = False
 
     def focusOutEvent(self, event):
         self.blinktimer.stop()
@@ -422,8 +458,17 @@ class NodeEditor(QFrame):
             if self.show_tool_visualisations:
                 # Draw footnotes.
                 infofont = QApplication.instance().tool_info_font
-                annotes = [annote.annotation for annote in node.get_annotations_with_hint(Footnote)]
-                footnote = " ".join(annotes)
+                annotes = []
+                annotes_ = node.get_annotations_with_hint(Footnote)
+                if self.hud_eval:
+                    for annote in annotes_:
+                        if annote.has_hint(Eval):
+                            annotes.append(annote)
+                elif self.hud_types:
+                    for annote in annotes_:
+                        if annote.has_hint(Types):
+                            annotes.append(annote)
+                footnote = " ".join([annote.annotation for annote in annotes])
                 if footnote.strip() != "":
                     if not self.tm.tool_data_is_dirty:
                         infofont.font.setBold(True)

--- a/lib/eco/overlay.py
+++ b/lib/eco/overlay.py
@@ -107,9 +107,9 @@ class Overlay(QWidget):
     def paintEvent(self, event):
         """Paint the visualisation of current tool data.
         """
-        if self._heatmap_data:
+        if self._heatmap_data and self.node_editor.hud_heat_map:
             self._paint_heatmap(event)
-        if self._railroad_data:
+        if self._railroad_data and self.node_editor.hud_callgraph:
             self._paint_railroad(event)
 
     def _paint_railroad(self, event):


### PR DESCRIPTION
This PR contains the eval() and types information from the recent JRuby callgraph changes. This was trickier than expected, because we don't yet have a generic solution to Issue #121 

The solution here allows the user to choose which visualisation they want to show in a heads-up display, out of a choice of:
- No HUD
- Callgraph
- eval() strings
- argument types
- heat map (currently heat map information is not available from JRuby)

Examples:
## HUD off

![hud-off](https://cloud.githubusercontent.com/assets/97674/16909162/0d7ede62-4cd1-11e6-9981-c703cf0d913a.png)
## Callgraph

![hud-callgraph](https://cloud.githubusercontent.com/assets/97674/16909164/16473ae4-4cd1-11e6-97c8-8480efe01e07.png)
## eval() strings

![hud-eval](https://cloud.githubusercontent.com/assets/97674/16909170/1f8b511c-4cd1-11e6-9811-15f5553db8f5.png)
## argument types

![hud-types](https://cloud.githubusercontent.com/assets/97674/16909176/283e61b4-4cd1-11e6-8b17-b9ac601cfc96.png)
