### PR TITLE
Put callgraph HUD into its own dock

### DIFF
--- a/lib/eco/eco.py
+++ b/lib/eco/eco.py
@@ -313,6 +313,7 @@ class SettingsView(QtGui.QMainWindow):
         # General pane.
         self.ui.gen_showconsole.setCheckState(settings.value("gen_showconsole", 0).toInt()[0])
         self.ui.gen_showparsestatus.setCheckState(settings.value("gen_showparsestatus", 2).toInt()[0])
+        self.ui.gen_showhud.setCheckState(settings.value("gen_showhud", 0).toInt()[0])
         # Appearance pane.
         family = settings.value("font-family").toString()
         size = settings.value("font-size").toInt()[0]
@@ -358,6 +359,7 @@ class SettingsView(QtGui.QMainWindow):
         # General pane.
         settings.setValue("gen_showconsole", self.ui.gen_showconsole.checkState())
         settings.setValue("gen_showparsestatus", self.ui.gen_showparsestatus.checkState())
+        settings.setValue("gen_showhud", self.ui.gen_showhud.checkState())
         settings.setValue("font-family", self.ui.app_fontfamily.currentFont().family())
         settings.setValue("font-size", self.ui.app_fontsize.value())
         settings.setValue("tool-font-family", self.ui.tool_info_fontfamily.currentFont().family())
@@ -646,8 +648,9 @@ class Window(QtGui.QMainWindow):
         self.connect(self.ui.tabWidget, SIGNAL("currentChanged(int)"), self.set_profiler_enabled)
         self.connect(self.ui.tabWidget, SIGNAL("currentChanged(int)"), self.set_debugger_enabled)
 
-        self.ui.menuWindow.addAction(self.ui.dockWidget_2.toggleViewAction())
         self.ui.menuWindow.addAction(self.ui.dockWidget.toggleViewAction())
+        self.ui.menuWindow.addAction(self.ui.dockWidget_2.toggleViewAction())
+        self.ui.menuWindow.addAction(self.ui.dockWidget_3.toggleViewAction())
 
         self.ui.teConsole.setFont(QApplication.instance().gfont.font)
         self.connect(self.ui.teConsole, SIGNAL("customContextMenuRequested(QPoint)"), self.consoleContextMenu)
@@ -680,6 +683,8 @@ class Window(QtGui.QMainWindow):
             self.ui.dockWidget.hide()
         if not settings.value("gen_showparsestatus", True).toBool():
             self.ui.dockWidget_2.hide()
+        if not settings.value("gen_showhud", False).toBool():
+            self.ui.dockWidget_3.hide()
 
         # hardcoded key bindings for OS X
         if sys.platform == "darwin":

--- a/lib/eco/gui/gui.ui
+++ b/lib/eco/gui/gui.ui
@@ -46,7 +46,7 @@
      <x>0</x>
      <y>0</y>
      <width>1069</width>
-     <height>26</height>
+     <height>23</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -206,51 +206,13 @@
     </size>
    </property>
    <property name="windowTitle">
-    <string>Parsing and HUD</string>
+    <string>Parsing</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>2</number>
    </attribute>
    <widget class="QWidget" name="dockWidgetContents_2">
     <layout class="QVBoxLayout" name="verticalLayout_2">
-     <item>
-      <widget class="QRadioButton" name="hud_off_button">
-       <property name="text">
-        <string>No HUD</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QRadioButton" name="hud_callgraph_button">
-       <property name="text">
-        <string>Callgraph</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QRadioButton" name="hud_types_button">
-       <property name="text">
-        <string>Types</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QRadioButton" name="hud_eval_button">
-       <property name="text">
-        <string>eval() strings</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QRadioButton" name="hud_heat_map_button">
-       <property name="text">
-        <string>Heat map</string>
-       </property>
-      </widget>
-     </item>
      <item>
       <widget class="QTreeWidget" name="treeWidget">
        <property name="alternatingRowColors">
@@ -313,6 +275,56 @@
       <widget class="QLineEdit" name="expressionBox">
        <property name="placeholderText">
         <string>Type an expression here</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+  </widget>
+  <widget class="QDockWidget" name="dockWidget_3">
+   <property name="windowTitle">
+    <string>HUD</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>2</number>
+   </attribute>
+   <widget class="QWidget" name="dockWidgetContents_3">
+    <layout class="QVBoxLayout" name="verticalLayout_3">
+     <item>
+      <widget class="QRadioButton" name="hud_off_button">
+       <property name="text">
+        <string>No HUD</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="hud_callgraph_button">
+       <property name="text">
+        <string>Callgraph</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="hud_types_button">
+       <property name="text">
+        <string>Types</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="hud_eval_button">
+       <property name="text">
+        <string>eval() strings</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="hud_heat_map_button">
+       <property name="text">
+        <string>Heat map</string>
        </property>
       </widget>
      </item>

--- a/lib/eco/gui/settings.ui
+++ b/lib/eco/gui/settings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>539</width>
-    <height>403</height>
+    <height>435</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -127,7 +127,7 @@
          <enum>QFrame::NoFrame</enum>
         </property>
         <property name="currentIndex">
-         <number>1</number>
+         <number>0</number>
         </property>
         <widget class="QWidget" name="page">
          <layout class="QFormLayout" name="formLayout_15">
@@ -166,6 +166,13 @@
                </property>
                <property name="checked">
                 <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QCheckBox" name="gen_showhud">
+               <property name="text">
+                <string>Show HUD</string>
                </property>
               </widget>
              </item>


### PR DESCRIPTION
Allow to hide the callgraph HUD without having to hide the parsing status as well.
