### PR TITLE
Remove the status bar.

### DIFF
--- a/lib/eco/gui/gui.ui
+++ b/lib/eco/gui/gui.ui
@@ -156,7 +156,6 @@
    <addaction name="menuWindow"/>
    <addaction name="menuInfo"/>
   </widget>
-  <widget class="QStatusBar" name="statusbar"/>
   <widget class="QToolBar" name="toolBar">
    <property name="windowTitle">
     <string>toolBar</string>


### PR DESCRIPTION
I don't think we ever use this, and it takes up a lot of vertical space. Before:

![image](https://cloud.githubusercontent.com/assets/20318/17814822/6e487d5e-6629-11e6-8c0e-28b38b530fc2.png)

After:

![image](https://cloud.githubusercontent.com/assets/20318/17814831/74be2206-6629-11e6-9aef-31449ebbe288.png)
