### PR TITLE
Hud improvements

### DIFF
--- a/lib/eco/debug.py
+++ b/lib/eco/debug.py
@@ -3,7 +3,7 @@ import telnetlib
 
 from PyQt4.QtCore import QObject, SIGNAL
 from fcntl import fcntl, F_GETFL, F_SETFL
-from os import O_NONBLOCK, read
+from os import O_NONBLOCK
 from socket import error as socket_error
 
 class Debugger(QObject):
@@ -20,9 +20,9 @@ class Debugger(QObject):
         self.signal_execute_fail = SIGNAL("executefail")
         self.telnet = None
 
-    def start_pdb(self):   
-        self.breakpoints = {'keep': [], 'del': []}      
-        self.line_read_until = '(Pdb)'   
+    def start_pdb(self):
+        self.breakpoints = {'keep': [], 'del': []}
+        self.line_read_until = '(Pdb)'
         self.process = self.window.getEditor().tm.export(debug=True)
         if not self.process:
             self.emit(self.signal_execute_fail)
@@ -35,25 +35,25 @@ class Debugger(QObject):
         while not self.telnet:
             sleep(0.5)
             try:
-                self.telnet = telnetlib.Telnet("localhost", 8210)   
+                self.telnet = telnetlib.Telnet("localhost", 8210)
             except socket_error:
-                if attempt > 3:              
+                if attempt > 3:
                     self.emit(self.signal_output, "Telnet connection failed, cannot debug")
                     self.exit()
                     return None
-                attempt += 1              
-        output = False     
+                attempt += 1
+        output = False
         while not output:
             sleep(0.1)
             output = self.telnet.read_until(self.line_read_until)
-        self.emit(self.signal_toggle_buttons, True)           
-        self.emit(self.signal_output, output)                    
+        self.emit(self.signal_toggle_buttons, True)
+        self.emit(self.signal_output, output)
 
     # Run command and wait for response
     def run_command(self, command):
         self.emit(self.signal_toggle_buttons, False)
         try:
-            self.telnet.write(command + "\n")             
+            self.telnet.write(command + "\n")
         except AttributeError:
             return None
         # If user quits then don't wait for (Pdb)
@@ -71,8 +71,8 @@ class Debugger(QObject):
         try:
             output = self.telnet.read_until(self.line_read_until)
         except (AttributeError, EOFError):
-            self.exit() 
-            return None               
+            self.exit()
+            return None
         if self.line_read_until not in output:
             self.exit()
             return None
@@ -96,7 +96,7 @@ class Debugger(QObject):
     def is_program_finished(self):
         try:
             # 'w' is the 'where' command. It tells you where you are in the program
-            self.telnet.write("w\n")  
+            self.telnet.write("w\n")
             output = self.telnet.read_until(self.line_read_until)
         except (AttributeError, EOFError):
             return True
@@ -109,10 +109,10 @@ class Debugger(QObject):
         return False
 
     def get_breakpoints(self, temp=False, number=0, get_all=True):
-        # Returns only the type of breakpoint specified (temp or not)        
+        # Returns only the type of breakpoint specified (temp or not)
         try:
             self.telnet.write("b\n")
-            output = self.telnet.read_until(self.line_read_until)          
+            output = self.telnet.read_until(self.line_read_until)
         except (EOFError, AttributeError):
             return None
         type_wanted = 'keep'
@@ -132,8 +132,8 @@ class Debugger(QObject):
             # No parameter for split - split by any whitespace
             words = l.split()
             # In all the lines needed, the first part is an integer
-            try: 
-                int(words[0])                    
+            try:
+                int(words[0])
             except ValueError:
                 continue
             # Breakpoints are numbered from 1 and goes up
@@ -142,9 +142,9 @@ class Debugger(QObject):
             if get_all:
                 # just add to the list
                 self.breakpoints[words[2]].append(words[5].split(":")[1])
-            else:            
+            else:
                 # check if it matches
-                for w in words:                
+                for w in words:
                     if w == type_wanted:
                         is_type = True
                     if is_type:
@@ -163,7 +163,7 @@ class Debugger(QObject):
         except OSError:
             pass
         if self.window.debugging:
-            if self.telnet:     
+            if self.telnet:
                 self.telnet.close()
-                self.emit(self.signal_output, "Debugging finished.")  
-            self.emit(self.signal_done)  
+                self.emit(self.signal_output, "Debugging finished.")
+            self.emit(self.signal_done)

--- a/lib/eco/eco.py
+++ b/lib/eco/eco.py
@@ -596,7 +596,6 @@ class Window(QtGui.QMainWindow):
         self.connect(self.ui.actionRun, SIGNAL("triggered()"), self.run_subprocess)
         self.connect(self.ui.actionDebug, SIGNAL("triggered()"), self.debug_subprocess)
         self.connect(self.ui.actionProfile, SIGNAL("triggered()"), self.profile_subprocess)
-        self.connect(self.ui.actionVisualise_automatically, SIGNAL("triggered()"), self.run_background_tools)
 
         try:
             import pydot
@@ -635,7 +634,6 @@ class Window(QtGui.QMainWindow):
         self.connect(self.ui.menuChange_language_box, SIGNAL("aboutToShow()"), self.showEditMenu)
         self.connect(self.ui.menuRecent_files, SIGNAL("aboutToShow()"), self.showRecentFiles)
         self.connect(self.ui.actionInput_log, SIGNAL("triggered()"), self.show_input_log)
-        self.connect(self.ui.actionShow_tool_visualisations, SIGNAL("triggered()"), self.toggle_overlay)
 
         # Debug buttons
         self.connect(self.ui.actionContinue, SIGNAL("triggered()"), self.debug_continue)
@@ -737,23 +735,11 @@ class Window(QtGui.QMainWindow):
         if (ed is not None) and (ed.tm is not None):
             self.ui.actionDebug.setEnabled(ed.tm.can_debug(ed.get_mainlanguage()))
 
-    def run_background_tools(self):
-        self.ui.actionShow_tool_visualisations.setChecked(True)
-        ed_tab = self.getEditor()
-        if ed_tab is not None:
-            ed_tab.run_background_tools = True
-        self.profiler_finished()
-
     def profiler_finished(self):
         self.profile_throbber.hide()
         ed_tab = self.getEditor()
-        if ed_tab is None:
-            return
-        if self.ui.actionVisualise_automatically.isChecked():
-            ed_tab.run_background_tools = True
-            self.profile_subprocess()
-        else:
-            ed_tab.run_background_tools = False
+        if ed_tab is not None:
+            ed_tab.update()
 
     def debug_finished(self):
         self.ui.expressionBox.hide()
@@ -761,27 +747,6 @@ class Window(QtGui.QMainWindow):
         self.debugging = False
         self.debug_t.exit()
         self.getEditorTab().is_debugging(False)
-
-    def draw_overlay(self, tool_data):
-        """Send profiler or tool information to the overlay object."""
-        ed_tab = self.getEditor()
-        if self.ui.actionShow_tool_visualisations.isChecked():
-            ed_tab.show_overlay()
-
-    def toggle_overlay(self):
-        ed_tab = self.getEditorTab()
-        ed_tab.show_tool_visualisation = self.ui.actionShow_tool_visualisations.isChecked()
-        ed_tab.editor.toggle_overlay()
-
-    def show_overlay(self):
-        self.ui.actionShow_tool_visualisations.setChecked(True)
-        ed_tab = self.getEditorTab()
-        ed_tab.editor.show_overlay()
-
-    def hide_overlay(self):
-        self.ui.actionShow_tool_visualisations.setChecked(False)
-        ed_tab = self.getEditorTab()
-        ed_tab.editor.hide_overlay()
 
     def consoleContextMenu(self, pos):
         def clear():
@@ -993,7 +958,6 @@ class Window(QtGui.QMainWindow):
 
     def profile_subprocess(self):
         self.ui.teConsole.clear()
-        self.ui.actionShow_tool_visualisations.setChecked(True)
         ed = self.getEditor()
         ed.tm.tool_data_is_dirty = False
         ed.overlay.clear_data()
@@ -1156,11 +1120,6 @@ class Window(QtGui.QMainWindow):
             self.delete_swap()
         else:
             self.savefileAs()
-        ed_ = self.getEditor()
-        if ed_.run_background_tools:
-            if self.thread_prof.isRunning():
-                self.thread_prof.quit()
-            self.profile_subprocess()
 
     def savefileAs(self):
         ed = self.getEditorTab()
@@ -1173,11 +1132,6 @@ class Window(QtGui.QMainWindow):
             self.add_to_recent_files(str(filename))
             self.getEditor().saveToJson(filename)
             self.getEditorTab().filename = filename
-        ed_ = self.getEditor()
-        if ed_.run_background_tools:
-            if self.thread_prof.isRunning():
-                self.thread_prof.quit()
-            self.profile_subprocess()
 
     def delete_swap(self):
         if self.getEditorTab().filename is None:
@@ -1301,12 +1255,6 @@ class Window(QtGui.QMainWindow):
     def tabChanged(self, index):
         ed_tab = self.getEditorTab()
         if ed_tab is not None:
-            if ed_tab.editor.is_overlay_visible():
-                self.ui.actionShow_tool_visualisations.setChecked(True)
-            else:
-                self.ui.actionShow_tool_visualisations.setChecked(False)
-            self.ui.actionVisualise_automatically.setChecked(ed_tab.editor.run_background_tools)
-
             if ed_tab.editor.tm.get_mainparser().graph:
                 self.ui.actionStateGraph.setEnabled(True)
             else:
@@ -1592,11 +1540,6 @@ def main():
     window.connect(window.thread_prof,
                    window.thread_prof.signal_done,
                    window.profiler_finished)
-    # Connect the profiler(tool) thread to the overlay which draws a heatmap
-    # or other visualisation.
-    window.connect(window.thread_prof,
-                   window.thread_prof.signal_overlay,
-                   window.draw_overlay)
 
     window.parse_options()
     window.show()

--- a/lib/eco/eco.py
+++ b/lib/eco/eco.py
@@ -1448,7 +1448,7 @@ class Window(QtGui.QMainWindow):
         self.ui.actionStepInto.setEnabled(enable)
         self.ui.actionStepOver.setEnabled(enable)
 
-    def debug_breakpoint(self, isTemp, number, from_click, 
+    def debug_breakpoint(self, isTemp, number, from_click,
         condition="", ignore=0, from_dialog=False):
         # If there is a breakpoint and the user double clicks it (from_click)
         # then the breakpoint should just be removed, don't make another one

--- a/lib/eco/eco.py
+++ b/lib/eco/eco.py
@@ -1260,6 +1260,16 @@ class Window(QtGui.QMainWindow):
             else:
                 self.ui.actionStateGraph.setEnabled(False)
             lang = ed_tab.editor.get_mainlanguage()
+            if ed_tab.editor.hud_callgraph:
+                self.ui.hud_callgraph_button.setChecked(True)
+            elif ed_tab.editor.hud_eval:
+                self.ui.hud_eval_button.setChecked(True)
+            elif ed_tab.editor.hud_types:
+                self.ui.hud_types_button.setChecked(True)
+            elif ed_tab.editor.hud_heat_map:
+                self.ui.hud_heat_map_button.setChecked(True)
+            else:
+                self.ui.hud_off_button.setChecked(True)
         else:
             self.toggle_menu(False)
         self.btReparse()

--- a/lib/eco/gui/gui.ui
+++ b/lib/eco/gui/gui.ui
@@ -84,7 +84,6 @@
     <addaction name="actionRun"/>
     <addaction name="actionDebug"/>
     <addaction name="actionProfile"/>
-    <addaction name="actionVisualise_automatically"/>
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
@@ -99,7 +98,6 @@
     <addaction name="actionShow_language_boxes"/>
     <addaction name="actionShow_namebinding"/>
     <addaction name="actionShow_indentation"/>
-    <addaction name="actionShow_tool_visualisations"/>
     <addaction name="actionShow_lspaceview"/>
    </widget>
    <widget class="QMenu" name="menuInfo">

--- a/lib/eco/nodeeditor.py
+++ b/lib/eco/nodeeditor.py
@@ -77,15 +77,8 @@ class NodeEditor(QFrame):
         # Semi-transparent overlay.
         # Used to display heat-map visualisation of profiler info, etc.
         self.overlay = Overlay(self)
-        # Start hidden, make (in)visible with self.toggle_overlay().
-        self.overlay.hide()
-
-        # Set to True if the user wants to see tool visualisations.
-        self.show_tool_visualisations = True
-
-        # Set True if Eco should be running profiler and other tools,
-        # continuously in the background.
-        self.run_background_tools = False
+        # Always show the overlay, users hide visualisations with the HUD.
+        self.overlay.show()
 
         # Show / don't show HUD visualisations.
         self.hud_callgraph = False
@@ -130,18 +123,6 @@ class NodeEditor(QFrame):
 
     def focusInEvent(self, event):
         self.blinktimer.start()
-
-    def toggle_overlay(self):
-        self.hide_overlay() if self.overlay.isVisible() else self.show_overlay()
-
-    def show_overlay(self):
-        self.overlay.show()
-
-    def hide_overlay(self):
-        self.overlay.hide()
-
-    def is_overlay_visible(self):
-        return self.overlay.isVisible()
 
     def resizeEvent(self, event):
         self.overlay.resize(event.size())
@@ -209,7 +190,8 @@ class NodeEditor(QFrame):
                 QToolTip.showText(event.globalPos(), msg)
                 return True
             # Draw annotations if there are any.
-            elif self.show_tool_visualisations:
+            elif (self.hud_callgraph or self.hud_eval or self.hud_types
+                  or self.hud_heat_map):
                 annotes = [annote.annotation for annote in node.get_annotations_with_hint(ToolTip)]
                 msg = "\n".join(annotes)
                 if msg.strip() != "":
@@ -455,8 +437,8 @@ class NodeEditor(QFrame):
             annotes = [annote.annotation for annote in node.get_annotations_with_hint(Heatmap)]
             for annote in annotes:
                 self.overlay.add_heatmap_datum(line + 1, annote)
-            if self.show_tool_visualisations:
-                # Draw footnotes.
+            if self.hud_eval or self.hud_types:
+                # If the user requested them, draw footnotes.
                 infofont = QApplication.instance().tool_info_font
                 annotes = []
                 annotes_ = node.get_annotations_with_hint(Footnote)


### PR DESCRIPTION
This PR improves two aspects of the UI behaviour of the existing HUD.

These changes:
- Remove some of the old UI elements that managed the visualisations (e.g. the "show tool visualisations" menu item). These are not needed now we have the HUD.
- Improve the behaviour of the HUD when changing tabs. Previously, if the user selected the "callgraph" visualisation in the HUD, the callgraph button remained down when the user changed tabs, even if the "new" tab did not have a callgraph visualisation available (or drawn). This is easier to see in the videos:

[Before bug fix video](https://youtu.be/dE2KUJiocgw)
[After bug fix video](https://youtu.be/f3AlewGvFUA)

NB: Will need squashing.
