### PR TITLE
Fix the HUD to work with languages other than JRuby

### DIFF
--- a/lib/eco/eco.py
+++ b/lib/eco/eco.py
@@ -656,11 +656,15 @@ class Window(QtGui.QMainWindow):
 
         # Set up HUD radio buttons.
         self.ui.hud_off_button.setChecked(True)
+        self.connect(self.ui.hud_off_button, SIGNAL("clicked()"), self.hud_off_toggle)
         self.connect(self.ui.hud_callgraph_button, SIGNAL("clicked()"), self.hud_callgraph_toggle)
         self.connect(self.ui.hud_eval_button, SIGNAL("clicked()"), self.hud_eval_toggle)
         self.connect(self.ui.hud_types_button, SIGNAL("clicked()"), self.hud_types_toggle)
         self.connect(self.ui.hud_heat_map_button, SIGNAL("clicked()"), self.hud_heat_map_toggle)
-        self.connect(self.ui.hud_off_button, SIGNAL("clicked()"), self.hud_off_toggle)
+        self.ui.hud_callgraph_button.setDisabled(True)
+        self.ui.hud_eval_button.setDisabled(True)
+        self.ui.hud_types_button.setDisabled(True)
+        self.ui.hud_heat_map_button.setDisabled(True)
 
         self.viewer = Viewer("pydot")
         self.pgviewer = None
@@ -1252,6 +1256,26 @@ class Window(QtGui.QMainWindow):
         elif(ret == QMessageBox.Discard):
             self.ui.tabWidget.removeTab(index)
 
+    def enable_hud_buttons(self, language):
+        """Enable the correct HUD buttons for the current language.
+        Never disables the hud_off button.
+        """
+        if language == "Python 2.7.5":
+            self.ui.hud_callgraph_button.setDisabled(True)
+            self.ui.hud_eval_button.setDisabled(True)
+            self.ui.hud_types_button.setDisabled(True)
+            self.ui.hud_heat_map_button.setDisabled(False)
+        elif language.startswith("Ruby"):  # Includes JRuby + SL, etc.
+            self.ui.hud_callgraph_button.setDisabled(False)
+            self.ui.hud_eval_button.setDisabled(False)
+            self.ui.hud_types_button.setDisabled(False)
+            self.ui.hud_heat_map_button.setDisabled(False)
+        else:
+            self.ui.hud_callgraph_button.setDisabled(True)
+            self.ui.hud_eval_button.setDisabled(True)
+            self.ui.hud_types_button.setDisabled(True)
+            self.ui.hud_heat_map_button.setDisabled(True)
+
     def tabChanged(self, index):
         ed_tab = self.getEditorTab()
         if ed_tab is not None:
@@ -1259,7 +1283,8 @@ class Window(QtGui.QMainWindow):
                 self.ui.actionStateGraph.setEnabled(True)
             else:
                 self.ui.actionStateGraph.setEnabled(False)
-            lang = ed_tab.editor.get_mainlanguage()
+            language = ed_tab.editor.get_mainlanguage()
+            self.enable_hud_buttons(language)
             if ed_tab.editor.hud_callgraph:
                 self.ui.hud_callgraph_button.setChecked(True)
             elif ed_tab.editor.hud_eval:

--- a/lib/eco/export/cpython.py
+++ b/lib/eco/export/cpython.py
@@ -63,7 +63,7 @@ class CPythonExporter(object):
         return subprocess.Popen(["python2", f[1]], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=0)
 
     def _debug(self):
-        f = tempfile.mkstemp(suffix='.py')        
+        f = tempfile.mkstemp(suffix='.py')
         code = self.tm.export_as_text(f[1])
 
         # Check if remote pdb installed
@@ -78,7 +78,7 @@ class CPythonExporter(object):
         """)
             return None
 
-        # These are the lines for remotepdb  
+        # These are the lines for remotepdb
         pdb_lines = """from remote_pdb import RemotePdb
 if hasattr(RemotePdb, 'DefaultConfig'):
     RemotePdb.DefaultConfig.prompt='(Pdb)'
@@ -86,7 +86,7 @@ if hasattr(RemotePdb, 'DefaultConfig'):
 RemotePdb('localhost', 8210).set_trace();"""
 
         with open(f[1], "w") as f2:
-            f2.write("".join(code))   
+            f2.write("".join(code))
 
         """ The pdb lines are passed in as a command line statement to python,
         and the actual file is imported in that statement.
@@ -95,7 +95,7 @@ RemotePdb('localhost', 8210).set_trace();"""
 
         # get only filename
         import_file = f[1].split("/tmp/")[1]
-        import_file = import_file.split(".py")[0]       
+        import_file = import_file.split(".py")[0]
         shell_command = ['python2', '-u', '-c', pdb_lines + "import " + import_file]
         return subprocess.Popen(shell_command,
         stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=0, cwd=tempfile.gettempdir())
@@ -146,7 +146,10 @@ RemotePdb('localhost', 8210).set_trace();"""
                     node = node.next_term
                 node.remove_annotations_by_class(CPythonFuncProfileMsg)
                 node.add_annotation(CPythonFuncProfileMsg(msg))
-                ncalls_dict[node] = float(ncalls)
+                if '/' in ncalls:
+                    ncalls_dict[node] = float(ncalls.split('/')[0])
+                else:
+                    ncalls_dict[node] = float(ncalls)
 
         # Normalise profiler information.
         vals = ncalls_dict.values()

--- a/lib/eco/export/cpython.py
+++ b/lib/eco/export/cpython.py
@@ -20,23 +20,33 @@
 # IN THE SOFTWARE.
 
 from mocks import MockPopen
-from incparser.annotation import Annotation, Heatmap, Footnote, ToolTip
+from incparser.annotation import Annotation, Heatmap, Footnote, ToolTip, HUDHeatmap
 import copy, os, os.path, subprocess, tempfile
 import sys
 
 class CPythonFuncProfileMsg(Annotation):
     def __init__(self, annotation):
-        self._hints = [ToolTip(), Footnote()]
+        self._hints = [ToolTip(), Footnote(), HUDHeatmap()]
         super(CPythonFuncProfileMsg, self).__init__(annotation)
 
     def get_hints(self):
         return self._hints
 
+    def has_hint(self, klass):
+        if klass in (Footnote, ToolTip, HUDHeatmap):
+            return True
+        return False
+
 
 class CPythonFuncProfileVal(Annotation):
     def __init__(self, annotation):
-        self._hints = [Heatmap()]
+        self._hints = [Heatmap(), HUDHeatmap()]
         super(CPythonFuncProfileVal, self).__init__(annotation)
+
+    def has_hint(self, klass):
+        if klass in (Heatmap, HUDHeatmap):
+            return True
+        return False
 
     def get_hints(self):
         return self._hints

--- a/lib/eco/export/jruby.py
+++ b/lib/eco/export/jruby.py
@@ -25,7 +25,8 @@ import os.path
 import tempfile
 import subprocess
 
-from incparser.annotation import Annotation, Footnote, ToolTip, Railroad, Eval, Types
+from incparser.annotation import Annotation, Footnote, ToolTip, Railroad
+from incparser.annotation import HUDEval, HUDTypes, HUDCallgraph, HUDHeatmap
 
 from incparser.astree import EOS
 from grammar_parser.gparser import MagicTerminal, IndentationTerminal
@@ -55,11 +56,11 @@ class JRubyMorphismMsg(Annotation):
     """
 
     def __init__(self, annotation):
-        self._hints = [ToolTip()]
+        self._hints = [ToolTip(), HUDCallgraph()]
         super(JRubyMorphismMsg, self).__init__(annotation)
 
     def has_hint(self, klass):
-        if klass == ToolTip:
+        if klass in (ToolTip, HUDCallgraph):
             return True
         return False
 
@@ -72,11 +73,11 @@ class JRubyArgumentTypes(Annotation):
     """
 
     def __init__(self, annotation):
-        self._hints = [Footnote(), Types()]
+        self._hints = [Footnote(), HUDTypes()]
         super(JRubyArgumentTypes, self).__init__(annotation)
 
     def has_hint(self, klass):
-        if klass == Footnote or klass == Types:
+        if klass in (Footnote, HUDTypes):
             return True
         return False
 
@@ -89,11 +90,11 @@ class JRubyEvalStrings(Annotation):
     """
 
     def __init__(self, annotation):
-        self._hints = [Footnote(), Eval()]
+        self._hints = [Footnote(), HUDEval()]
         super(JRubyEvalStrings, self).__init__(annotation)
 
     def has_hint(self, klass):
-        if klass == Footnote or klass == Eval:
+        if klass in (Footnote, HUDEval):
             return True
         return False
 

--- a/lib/eco/export/simple_language.py
+++ b/lib/eco/export/simple_language.py
@@ -23,25 +23,6 @@ import tempfile
 import subprocess
 
 from PyQt4.QtCore import QSettings
-from incparser.annotation import Annotation, ToolTip, Heatmap
-
-
-class SLCoverageCounterMsg(Annotation):
-    def __init__(self, annotation):
-        self._hints = [ToolTip()]
-        super(SLCoverageCounterMsg, self).__init__(annotation)
-
-    def get_hints(self):
-        return self._hints
-
-
-class SLCoverageCounterVal(Annotation):
-    def __init__(self, annotation):
-        self._hints = [Heatmap()]
-        super(SLCoverageCounterVal, self).__init__(annotation)
-
-    def get_hints(self):
-        return self._hints
 
 
 class SimpleLanguageExporter(object):

--- a/lib/eco/incparser/annotation.py
+++ b/lib/eco/incparser/annotation.py
@@ -43,17 +43,28 @@ class ToolTip(Hint):
     pass
 
 
-class Eval(Hint):
+class HUDEval(Hint):
     """Annotations displayed when the HUD eval() strings button is down.
     """
     pass
 
 
-class Types(Hint):
+class HUDTypes(Hint):
     """Annotations displayed when the HUD types button is down.
     """
     pass
 
+
+class HUDHeatmap(Hint):
+    """Annotations displayed when the HUD heatmap button is down.
+    """
+    pass
+
+
+class HUDCallgraph(Hint):
+    """Annotations displayed when the HUD call graph button is down.
+    """
+    pass
 
 class Annotation(object):
     """An Annotation is a piece of information related to a node.


### PR DESCRIPTION
- Fixes an old bug in cPython profiling
- Greys out HUD buttons for languages that cannot provide HUD information 
  [see this video for an example](https://youtu.be/zFFjqm90zDc)
- Displays onle the tooltips etc. that the user has requested via the HUD. 

e.g. user has selected callgraph information:

![hud-with-tooltip](https://cloud.githubusercontent.com/assets/97674/18203448/075b90b8-710f-11e6-85db-bc5be6bd2828.png)

Here the user has selected "No HUD" so the tooltip is not displayed:

![no-hud-no-tooltip](https://cloud.githubusercontent.com/assets/97674/18203456/17830b24-710f-11e6-8483-0205f3276a58.png)

Fixes #107 
