### PR TITLE
Show all errors in the UI

### DIFF
--- a/lib/eco/eco.py
+++ b/lib/eco/eco.py
@@ -1371,8 +1371,8 @@ class Window(QtGui.QMainWindow):
                 qtreeitem.setIcon(0, QIcon("gui/accept.png"))
             else:
                 qtreeitem.setIcon(0, QIcon("gui/exclamation.png"))
-                enode = parser.error_node
-                if enode:
+                if parser.error_nodes:
+                    enode = parser.error_nodes[0]
                     emsg = "Error on \"%s\"" % (enode.symbol.name,)
                     qtreeitem.setToolTip(0, emsg)
             qtreeitem.parser = parser

--- a/lib/eco/grammar_parser/bootstrap.py
+++ b/lib/eco/grammar_parser/bootstrap.py
@@ -75,7 +75,7 @@ class BootstrapParser(object):
         self.treemanager.add_parser(self.parser, self.lexer, grammar.name)
         self.treemanager.import_file(ecogrammar)
         if self.parser.last_status == False:
-            raise Exception("Invalid input grammar: at %s %s" % (self.parser.error_node.prev_term, self.parser.error_node))
+            raise Exception("Invalid input grammar due to syntax errors")
         self.read_options()
         self.parse_both()
         self.create_parser()

--- a/lib/eco/incparser/incparser.py
+++ b/lib/eco/incparser/incparser.py
@@ -93,10 +93,9 @@ class IncParser(object):
         self.last_shift_state = 0
         self.validating = False
         self.last_status = False
-        self.error_node = None
         self.whitespaces = whitespaces
         self.status_by_version = {}
-        self.errornode_by_version = {}
+        self.errornodes_by_version = {}
         self.indentation_based = False
 
         self.previous_version = None
@@ -145,7 +144,6 @@ class IncParser(object):
         logging.debug("============ NEW INCREMENTAL PARSE ================= ")
         logging.debug("= starting in state %s ", state)
         self.validating = False
-        self.error_node = None
         self.reused_nodes = set()
         self.current_state = state
         bos = self.previous_version.parent.children[0]
@@ -320,7 +318,6 @@ class IncParser(object):
                 self.validating = False
             else:
                 self.error_nodes.append(la)
-                self.error_node = la
                 if self.rm.recover(la):
                     # recovered, continue parsing
                     self.refine(self.rm.iso_node, self.rm.iso_offset, self.rm.error_offset)
@@ -777,7 +774,6 @@ class IncParser(object):
         self.last_shift_state = 0
         self.validating = False
         self.last_status = False
-        self.error_node = None
         self.previous_version = None
         self.init_ast()
 
@@ -787,13 +783,13 @@ class IncParser(object):
         except KeyError:
             logging.warning("Could not find status for version %s", version)
         try:
-            self.error_node = self.errornode_by_version[version]
+            self.error_nodes = list(self.errornodes_by_version[version])
         except KeyError:
-            logging.warning("Could not find errornode for version %s", version)
+            logging.warning("Could not find errornodes for version %s", version)
 
     def save_status(self, version):
         self.status_by_version[version] = self.last_status
-        self.errornode_by_version[version] = self.error_node
+        self.errornodes_by_version[version] = list(self.error_nodes)
 
     def find_nested_error(self, node):
         """Given an isolated node, finds the first local error node contained in

--- a/lib/eco/test/test_eco.py
+++ b/lib/eco/test/test_eco.py
@@ -3529,16 +3529,16 @@ class Test_ErrorRecovery(Test_Helper):
         self.treemanager.key_normal("*")
         self.treemanager.key_normal("3")
         assert self.parser.last_status == False
-        assert self.parser.error_node is not None
+        assert len(self.parser.error_nodes) > 0
 
         # continue after successful out-of-context analysis and integration
         self.treemanager.key_normal("+")
         assert self.parser.last_status == False
-        assert self.parser.error_node is not None
+        assert len(self.parser.error_nodes) > 0
 
         self.treemanager.key_normal("3")
         assert self.parser.last_status == False
-        assert self.parser.error_node is not None
+        assert len(self.parser.error_nodes) > 0
 
     def test_temp(self):
         self.reset()

--- a/lib/eco/treemanager.py
+++ b/lib/eco/treemanager.py
@@ -495,17 +495,23 @@ class TreeManager(object):
         lbox = root.get_magicterminal()
         return lbox
 
-    def has_error(self, node):
+    def is_typeerror(self, node):
         for p in self.parsers:
             if p[3] and p[3].has_error(node):
                 return True
         return False
 
-    def get_error(self, node):
+    def is_syntaxerror(self, node):
         for p in self.parsers:
-            # check for syntax error
-            if node is p[0].error_node:
-                return "Syntax error on token '%s' (%s)." % (node.symbol.name, node.lookup)
+            if p[0] and node in p[0].error_nodes:
+                return True
+        return False
+
+    def get_error(self, node):
+        if self.is_syntaxerror(node):
+            return "Syntax error on token '%s' (%s)." % (node.symbol.name, node.lookup)
+
+        for p in self.parsers:
             # check for namebinding error
             if p[3]:
                 error = p[3].get_error(node)


### PR DESCRIPTION
This PR adds changes that allow the editor to display all errors (using squiggly lines) instead of just one like before.