### PR TITLE
Reuse old indentation nodes

### DIFF
--- a/lib/eco/test/test_eco.py
+++ b/lib/eco/test/test_eco.py
@@ -1298,6 +1298,21 @@ def z():
         self.treemanager.import_file(inputstring)
         assert self.parser.last_status == True
 
+    def test_indentation_reuse(self):
+        self.reset()
+        for c in """class X:\n    """:
+            self.treemanager.key_normal(c)
+
+        newline = self.treemanager.cursor.node.next_term
+        assert newline.symbol.name == "NEWLINE"
+
+        self.treemanager.key_normal("p")
+
+        newline2 = self.treemanager.cursor.node.next_term
+        assert newline2.symbol.name == "NEWLINE"
+
+        assert newline is newline2
+
 class Test_Relexing(Test_Python):
 
     def test_dont_stop_relexing_after_first_error(self):


### PR DESCRIPTION
This is a small optimisation that tries to reuse more indentation nodes than the previous approach. Until now indentation nodes were only reused if all indentation nodes in a line stayed the same. Otherwise the algorithm would first remove all indentation nodes and then insert the new ones. This sometimes lead to indentation nodes being replaced by the same node.

The new algorithm looks at each indentation node individually and compares them with the new indentation node that replaces it. Equal nodes are then skipped and not removed and re-inserted.