### PR TITLE
Avoid error highlighting wrong nodes

### DIFF
--- a/lib/eco/eco.py
+++ b/lib/eco/eco.py
@@ -1391,10 +1391,6 @@ class Window(QtGui.QMainWindow):
                 qtreeitem.setIcon(0, QIcon("gui/accept.png"))
             else:
                 qtreeitem.setIcon(0, QIcon("gui/exclamation.png"))
-                if parser.error_nodes:
-                    enode = parser.error_nodes[0]
-                    emsg = "Error on \"%s\"" % (enode.symbol.name,)
-                    qtreeitem.setToolTip(0, emsg)
             qtreeitem.parser = parser
             self.add_parsingstatus(nested, parser.previous_version.parent, qtreeitem)
 

--- a/lib/eco/treemanager.py
+++ b/lib/eco/treemanager.py
@@ -503,8 +503,10 @@ class TreeManager(object):
 
     def is_syntaxerror(self, node):
         for p in self.parsers:
-            if p[0] and node in p[0].error_nodes:
-                return True
+            if p[0]:
+                for n in p[0].error_nodes:
+                    if n is node:
+                        return True
         return False
 
     def get_error(self, node):


### PR DESCRIPTION
Fixes the highlighting of nodes that are equal to the error node