### PR TITLE
Revert back to the default travis timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 script:
 - if [ "${TRAVIS_PULL_REQUEST}" == "false" ] && [ "${TRAVIS_BRANCH}" == "master" ] ;
   then
-     cd lib/eco; travis_wait 30 py.test test/test_eco.py --runslow ;
+     cd lib/eco; py.test test/test_eco.py --runslow ;
    else
-     cd lib/eco; travis_wait 30 py.test test/test_eco.py ;
+     cd lib/eco; py.test test/test_eco.py ;
   fi


### PR DESCRIPTION
Adding the `travis_wait` command somehow decreased the maximum timeout instead of increasing it to 30 minutes. Since then we merged a PR that increases the build times so hopefully there won't be any more timeouts even with the default travis setting.