### PR TITLE
Show node changes that are actually responsible for an error

### DIFF
--- a/lib/eco/nodeeditor.py
+++ b/lib/eco/nodeeditor.py
@@ -201,6 +201,8 @@ class NodeEditor(QFrame):
                 return True
             # Draw errors, if there are any.
             msg = self.tm.get_error(node)
+            if not msg:
+                msg = self.tm.get_error_presentation(node)
             if msg:
                 QToolTip.showText(event.globalPos(), msg)
                 return True
@@ -544,6 +546,10 @@ class NodeEditor(QFrame):
             if show_namebinding and self.tm.is_typeerror(node):
                 length = len(node.symbol.name)*self.fontwt
                 self.draw_squiggly_line(paint, x-length, y, length, "orange")
+
+            if self.tm.has_error_presentation(node):
+                length = len(node.symbol.name)*self.fontwt
+                self.draw_squiggly_line(paint, x-length, y, length, "green")
 
             if self.tm.is_syntaxerror(node):
                 if isinstance(node, EOS):

--- a/lib/eco/treemanager.py
+++ b/lib/eco/treemanager.py
@@ -370,6 +370,7 @@ class TreeManager(object):
         self.changed = False
         self.last_search = ""
         self.version = self.global_version = 1
+        self.reference_version = 0
         TreeManager.version = 1
         self.last_saved_version = 1
         self.savenextparse = False
@@ -520,6 +521,22 @@ class TreeManager(object):
                 if error != "":
                     return error
         return ""
+
+    def has_error_presentation(self, node):
+        for p in self.parsers:
+            if p[0]:
+                for n, pres in p[0].error_pres:
+                    if n is node:
+                        return True
+        return False
+
+    def get_error_presentation(self, node):
+        for p in self.parsers:
+            if p[0]:
+                for n, pres in p[0].error_pres:
+                      if n is node:
+                          return "'%s' was changed to '%s'" % (pres, node.symbol.name)
+        return None
 
     def analyse(self):
         if self.parsers[0][2] == "PHP + Python":
@@ -1843,6 +1860,7 @@ class TreeManager(object):
             parser = self.get_parser(root)
             self.previous_version = self.version
             parser.prev_version = self.version
+            parser.reference_version = self.reference_version
             parser.inc_parse()
             self.save_current_version(postparse=True) # save post parse tree
             if parser.last_status == True:


### PR DESCRIPTION
When a syntax error happens the reason for that error is rarely the node that causes the parsing error. Mostly another node had been changed earlier and the parser only fails later trying to make sense of the change. This PR also marks all changes that have been made between the last correct program to the current erroneous program and highlights them in the editor (alongside the syntax error).