### PR TITLE
Speedup loading cached grammars

### DIFF
--- a/lib/eco/grammars/grammars.py
+++ b/lib/eco/grammars/grammars.py
@@ -52,26 +52,14 @@ class EcoFile(object):
     def load(self):
         from grammar_parser.bootstrap import BootstrapParser
         from jsonmanager import JsonManager
+        from incparser.incparser import IncParser
 
         if _cache.has_key(self.name + "::parser"):
 
-            root, language, whitespaces = _cache[self.name + "::json"]
-
-            # parse rules as they are needed by the incremental parser to
-            # detect comments
-
-            manager = JsonManager(unescape=True)
-            root, language, whitespaces = manager.load(self.filename)[0]
-
-            pickle_id = hash(self)
-            bootstrap = BootstrapParser(lr_type=1, whitespaces=whitespaces)
-            bootstrap.ast = root
-            bootstrap.parse_rules(root.children[1].children[1].children[0])
-
-            pickle_id, whitespace = _cache[self.name + "::parser"]
-            from incparser.incparser import IncParser
+            syntaxtable, whitespaces = _cache[self.name + "::parser"]
             incparser = IncParser()
-            incparser.from_dict(bootstrap.rules, None, None, whitespace, pickle_id, None)
+            incparser.syntaxtable = syntaxtable
+            incparser.whitespaces = whitespaces
             incparser.init_ast()
 
             inclexer = _cache[self.name + "::lexer"]
@@ -96,7 +84,7 @@ class EcoFile(object):
 
             _cache[self.name + "::lexer"] = bootstrap.inclexer
             _cache[self.name + "::json"] = (root, language, whitespaces)
-            _cache[self.name + "::parser"] = (pickle_id, whitespace)
+            _cache[self.name + "::parser"] = (bootstrap.incparser.syntaxtable, whitespace)
 
             bootstrap.incparser.lexer = bootstrap.inclexer
             return (bootstrap.incparser, bootstrap.inclexer)


### PR DESCRIPTION
This PR introduces an optimisation that I discovered while working on the auto language boxes. I realised that inserting new language boxes was quite slow (maybe half a second). Seeking to optimise this, I noticed that each time a new language box is created, the syntaxtable for that language is loaded from the disk. This of course is not needed if we already have that language loaded and only results in unnecessary slowdown on every additional language box we add to the program.

This PR optimises this by caching the syntaxtable the first time it is loaded and then shares that syntaxtable between all incremental parsers of the same language. This not only makes any additional language box to appear instantly, it also reduces the time of our tests suite from 90 to 37 seconds (on my machine).

The improvement can easily be tested by creating a Python + SQL program, and then adding multiple SQL language boxes. To optimise this further we could preload all valid language boxes when we create a new file, which would also get rid of the small lag when creating the first language box. Thoughts?