### PR TITLE
Fixed bug where deleting a selection is really slow

### DIFF
--- a/lib/eco/inclexer/inclexer.py
+++ b/lib/eco/inclexer/inclexer.py
@@ -515,8 +515,11 @@ class IncrementalLexerCF(object):
             try:
                 token = next_token()
                 lookaheads.append(token[2])
-                if token[3][0] is startnode:
-                    past_startnode = True
+                if not past_startnode:
+                    for temp in token[3]:
+                        if temp is startnode:
+                            past_startnode = True
+                            break
                 toks.append(token[:3])
                 tokenslength += len(token[0])
                 for r in token[3]:


### PR DESCRIPTION
When incrementally relexing a node, the algorithm stops when a token is relexed to the same value; only, however, if we passed the initial node where relexing started. There was a bug that when the initial startnode was merged with it's left neighbor, the algorithm wouldn't notice that we passed the startnode and thus relex the entire file. This fix alters the check so that a merged startnode also triggers the `past_startnode` flag.