### PR TITLE
Fix PyQt4 dependency on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,19 @@ python: "2.7"
 virtualenv:
   system_site_packages: true
 
-addons:
-  apt:
-    packages:
-      python-qt4
-
 cache:
   directories:
     - lib/eco/pickle
 
 install:
     - "pip install py"
+    - mkdir downloads
+    - curl -L -o downloads/sip.tar.gz https://sourceforge.net/projects/pyqt/files/sip/sip-4.19.3/sip-4.19.3.tar.gz
+    - curl -L -o downloads/pyqt.tar.gz http://sourceforge.net/projects/pyqt/files/PyQt4/PyQt-4.12.1/PyQt4_gpl_x11-4.12.1.tar.gz
+    - tar xzf downloads/sip.tar.gz -C downloads --keep-newer-files
+    - tar xzf downloads/pyqt.tar.gz -C downloads --keep-newer-files
+    - cd downloads/sip-4.19.3 && python configure.py && sudo make && sudo make install && cd ../../
+    - cd downloads/PyQt4_gpl_x11-4.12.1 && python configure.py --confirm-license && sudo make && sudo make install && cd ../../
 
 script:
 - if [ "${TRAVIS_PULL_REQUEST}" == "false" ] && [ "${TRAVIS_BRANCH}" == "master" ] ;


### PR DESCRIPTION
Since travis switched to Ubuntu Trusty we can't install dependencies via apt and use them with `system_site_packages` anymore. Since our tests depend on PyQt4 we have to manually build and install it ourselves.