### PR TITLE
Fix pygame bug when drawing parse trees

### DIFF
--- a/lib/eco/dotviewer/drawgraph.py
+++ b/lib/eco/dotviewer/drawgraph.py
@@ -501,7 +501,7 @@ class GraphRenderer:
         if node.shape == 'box':
             rect = (x-1, y-1, boxwidth+2, boxheight+2)
             def cmd():
-                self.screen.fill(bgcolor, rect)
+                pygame.draw.rect(self.screen, bgcolor, rect)
             bkgndcommands.append(cmd)
             def cmd():
                 pygame.draw.rect(self.screen, fgcolor, rect, 1)


### PR DESCRIPTION
It is recommended to draw rectangles using surface.fill(). However, there seems to be a bug where those rectangles can't be drawn outside of the viewport and instead are drawn at position 0. Switching to  draw.rect() fixes this.

You can check this by inspecting a parse tree and then moving the view around. The white background rectangles of the tree nodes won't move outside the view prior to this fix. I upgraded my pygame version thinking this bug might have been fixed but it still seems to be there.