### PR TITLE
Fixed retainability check

### DIFF
--- a/lib/eco/incparser/astree.py
+++ b/lib/eco/incparser/astree.py
@@ -40,55 +40,6 @@ class AST(object):
     def get_bos(self):
         return self.parent.children[0]
 
-    def get_nodes_at_position(self, pos, a=None, b=None):
-        """
-        Searches all nodes that match the current cursor position in the TextField.
-        As a side effect all passed nodes are updated with their position in the document.
-        """
-        print("================== get nodes at pos ================== ")
-        progress = 0
-        node = self.parent.children[0]
-        while node is not None:
-            node.position = progress
-            progress += len(node.symbol.name)
-
-            print("node", node)
-            if pos < progress:
-                return [node, None]
-
-            if pos == progress:
-                print("pos == progress")
-                other = node.next_terminal()
-                print("other", other)
-                other.position = progress
-                return [node, other]
-
-            node = node.next_terminal()
-        print ("================ end get nodes at pos ================ ")
-
-
-    def get_nodes_at_position_old(self, pos, node=None, bla=0):
-        print("Progress:", self.progress, "Node", node)
-        if node is None:
-           node = self.parent#.children[1]
-
-        if isinstance(node.symbol, Nonterminal):
-            for child in node.children:
-                result = self.get_nodes_at_position(pos, child, self.progress)
-                if result != []:
-                    self.progress = 0
-                    return result
-        else:
-            nodes = []
-            if pos <= self.progress + len(node.symbol.name):
-                nodes.append(node)
-
-            if pos == self.progress + len(node.symbol.name):
-                nodes.append(node.next_terminal())
-
-            self.progress += len(node.symbol.name)
-            return nodes
-
     def find_node_at_pos(self, pos, node=None): #recursive
         if node is None:
            node = self.parent.children[1]

--- a/lib/eco/incparser/astree.py
+++ b/lib/eco/incparser/astree.py
@@ -201,6 +201,7 @@ class Node(object):
         self.log[("nested_errors", version)] = self.nested_errors
         self.log[("local_error", version)] = self.local_error
         self.log[("textlen", version)] = self.textlen
+        self.log[("position", version)] = self.position
         self.log[("isolated", version)] = self.isolated
         self.log[("version", version)] = version
         if self.new:
@@ -225,6 +226,7 @@ class Node(object):
                 self.local_error = self.log[("local_error", version)]
                 self.nested_errors = self.log[("nested_errors", version)]
                 self.textlen = self.log[("textlen", version)]
+                self.position = self.log[("position", version)]
                 self.isolated = self.log[("isolated", version)]
                 self.version = version
                 return

--- a/lib/eco/incparser/incparser.py
+++ b/lib/eco/incparser/incparser.py
@@ -451,10 +451,9 @@ class IncParser(object):
             # if no changes, discarding doesn't do anything anyways so why check?
             return True
 
-        # XXX This is equivalent to Wagner's `same_pos` function. His
-        # description suggests we also need to check for changed offsets.
-        # Unfortunately, we currently don't have this information at this point.
-        if node.textlength(self.prev_version) == node.textlength():
+        # This is equivalent to Wagner's `same_pos` function.
+        if node.textlength(self.prev_version) == node.textlength() and \
+                node.get_attr("position", self.prev_version) == node.position:
             return True
 
         return False
@@ -661,6 +660,7 @@ class IncParser(object):
             logging.debug("   No reuse parent. Make new %s (%s)", new_node, id(new_node))
         new_node.nested_errors = has_errors
         new_node.calc_textlength()
+        new_node.position = self.stack[-1].position + self.stack[-1].textlen
         logging.debug("   Add %s to stack and goto state %s", new_node.symbol, new_node.state)
         self.stack.append(new_node)
         new_node.exists = True
@@ -762,6 +762,7 @@ class IncParser(object):
         logging.debug("\x1b[32m" + "%sShift(%s)" + "\x1b[0m" + ": %s -> %s", "rb" if rb else "", self.current_state, la, element)
         la.state = element.action
         la.exists = True
+        la.position = self.stack[-1].position + self.stack[-1].textlen
         self.stack.append(la)
         self.current_state = la.state
 

--- a/lib/eco/test/test_eco.py
+++ b/lib/eco/test/test_eco.py
@@ -3060,8 +3060,10 @@ class Test_Undo(Test_Python):
     def test_undo_random_insertdelete(self):
         import random
         self.reset()
+        print("self.reset()")
         #self.save()
 
+        print("self.treemanager.import_file(programs.connect4)")
         self.treemanager.import_file(programs.connect4)
         assert self.parser.last_status == True
         #self.save()
@@ -3077,17 +3079,24 @@ class Test_Undo(Test_Python):
             cols = range(20)
             random.shuffle(cols)
             for col in cols:
+                print("self.treemanager.cursor_reset()")
+                print("self.move(%s, %s)" % (DOWN, linenr))
+                print("self.move(%s, %s)" % (RIGHT, col))
                 self.treemanager.cursor_reset()
                 self.move(DOWN, linenr)
                 self.move(RIGHT, col)
                 k = self.get_random_key()
                 if k in ["a", "c", "e", "g", "i", "k", "m", "1", "3", "5", "7"]:
                     # for a few characters DELETE instead of INSERT
+                    print("self.treemanager.key_delete()")
                     x = self.treemanager.key_delete()
                 else:
-                    x = self.treemanager.key_normal(self.get_random_key())
+                    rk = self.get_random_key()
+                    print("self.treemanager.key_normal(%s)" % rk)
+                    x = self.treemanager.key_normal(rk)
                 if x == "eos":
                     continue
+            print("self.treemanager.undo_snapshot()")
             self.treemanager.undo_snapshot()
 
         end_version = self.treemanager.version

--- a/lib/eco/test/test_eco.py
+++ b/lib/eco/test/test_eco.py
@@ -3382,6 +3382,201 @@ class Test_Undo(Test_Python):
         self.move(RIGHT, 1)
         self.treemanager.key_normal('=')
 
+    def test_undo_random_insertdeleteundo_bug8(self):
+        self.reset()
+        self.treemanager.import_file("""class Connect4():
+    UI_DEPTH = 5
+
+    def __init__():
+        self.top = tk.Tk()
+        self.top.title()
+
+        self.turn = None
+        self.ai_players = 1
+
+        pass""")
+
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 8)
+        self.move(RIGHT, 18)
+        self.treemanager.key_delete()
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 8)
+        self.move(RIGHT, 6)
+        self.treemanager.key_normal('4')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 8)
+        self.move(RIGHT, 11)
+        self.treemanager.key_normal(')')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 8)
+        self.move(RIGHT, 13)
+        self.treemanager.key_normal('n')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 8)
+        self.move(RIGHT, 2)
+        self.treemanager.key_normal('9')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 8)
+        self.move(RIGHT, 2)
+        self.treemanager.key_normal('&')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 8)
+        self.move(RIGHT, 3)
+        self.treemanager.key_normal('+')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 8)
+        self.move(RIGHT, 14)
+        self.treemanager.key_normal('5')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 8)
+        self.move(RIGHT, 0)
+        self.treemanager.key_normal(',')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 8)
+        self.move(RIGHT, 0)
+        self.treemanager.key_normal('1')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 8)
+        self.move(RIGHT, 7)
+        self.treemanager.key_normal('c')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 8)
+        self.move(RIGHT, 9)
+        self.treemanager.key_normal('(')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 8)
+        self.move(RIGHT, 15)
+        self.treemanager.key_normal('*')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 4)
+        self.move(RIGHT, 6)
+        self.treemanager.key_normal('}')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 4)
+        self.move(RIGHT, 4)
+        self.treemanager.key_normal('v')
+
+    def test_undo_random_insertdeleteundo_bug8_loop(self):
+        self.reset()
+        self.treemanager.import_file("""class Connect4():
+    UI_DEPTH = 5
+
+    def __init__():
+        self.top = tk.Tk()
+        self.top.title()
+
+        self.turn = None
+        self.ai_players = 1
+
+        pass""")
+
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 8)
+        self.move(RIGHT, 18)
+        self.treemanager.key_delete()
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 8)
+        self.move(RIGHT, 6)
+        self.treemanager.key_normal('4')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 8)
+        self.move(RIGHT, 11)
+        self.treemanager.key_normal(')')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 8)
+        self.move(RIGHT, 13)
+        self.treemanager.key_normal('n')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 8)
+        self.move(RIGHT, 2)
+        self.treemanager.key_normal('9')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 8)
+        self.move(RIGHT, 2)
+        self.treemanager.key_normal('&')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 8)
+        self.move(RIGHT, 3)
+        self.treemanager.key_normal('+')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 8)
+        self.move(RIGHT, 14)
+        self.treemanager.key_normal('5')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 8)
+        self.move(RIGHT, 0)
+        self.treemanager.key_normal(',')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 8)
+        self.move(RIGHT, 0)
+        self.treemanager.key_normal('1')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 8)
+        self.move(RIGHT, 7)
+        self.treemanager.key_normal('c')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 8)
+        self.move(RIGHT, 15)
+        self.treemanager.key_normal('*')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 8)
+        self.move(RIGHT, 9)
+        self.treemanager.key_normal('(')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 4)
+        self.move(RIGHT, 6)
+        self.treemanager.key_normal('}')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 4)
+        self.move(RIGHT, 4)
+        self.treemanager.key_normal('v')
+
+    def test_undo_random_insertdeleteundo_bug9(self):
+        """This test fails if the retainablity check doesn't include a same_pos
+        check as described by Wagner. The node `(` which pre-parse is a child of
+        `atom` is moved outside of (and before) `atom` during the parse. Then
+        error recovery happens and `atom` is checked for retainablity, but now
+        it does not contain `(` but instead has gained a newline. This means the
+        textlength-check succeeds, but it's position has changed due to `(` now
+        being before `atom`. So the retain check must fail."""
+        self.reset()
+        self.treemanager.import_file("""class Connect4():
+    def __init__():
+        self.top
+
+        self.newgamebutton
+        self.new""")
+
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 4)
+        self.move(RIGHT, 9)
+        self.treemanager.key_normal('(')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 4)
+        self.move(RIGHT, 13)
+        self.treemanager.key_delete()
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 4)
+        self.move(RIGHT, 8)
+        self.treemanager.key_delete()
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 4)
+        self.move(RIGHT, 9)
+        self.treemanager.key_normal(' ')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 4)
+        self.move(RIGHT, 6)
+        self.treemanager.key_delete()
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 4)
+        self.move(RIGHT, 4)
+        self.treemanager.key_normal('=')
+        self.treemanager.cursor_reset()
+        self.move(DOWN, 4)
+        self.move(RIGHT, 3)
+        self.treemanager.key_normal('[')
+
     def random_insert_delete_undo(self, program):
         import random
         self.reset()


### PR DESCRIPTION
A node can be retained if its content has the same textlength and the node
has the same position as before parsing. Previously we only checked
that the textlength matches. This commit adds the position check to
the retainability query.