### PR TITLE
Increase travis timeout for slow running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
 script:
 - if [ "${TRAVIS_PULL_REQUEST}" == "false" ] && [ "${TRAVIS_BRANCH}" == "master" ] ;
   then
-     cd lib/eco; py.test test/test_eco.py --runslow ;
+     cd lib/eco; travis_wait 30 py.test test/test_eco.py --runslow ;
    else
      cd lib/eco; py.test test/test_eco.py ;
   fi


### PR DESCRIPTION
Giving travis_wait another go. It ran fine within this branch (I temporarily activated slow tests for branches as well and removed the commit afterwards). Let's this fixes the timed out tests on master.