### PR TITLE
Fix potential problems with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
 script:
 - if [ "${TRAVIS_PULL_REQUEST}" == "false" ] && [ "${TRAVIS_BRANCH}" == "master" ] ;
   then
-     cd lib/eco; travis_wait 30 py.test test/test_eco.py --runslow ;
+     cd lib/eco; py.test test/test_eco.py; py.test test/test_eco.py --justslow
    else
      cd lib/eco; py.test test/test_eco.py ;
   fi


### PR DESCRIPTION
When running the tests on travis, run all the normal tests first.
This allows travis to cache the build grammars. Then in a seperate
process run the only the fuzzy tests. Hopefully, this will get rid
of the issues we've been having with travis lately.