### PR TITLE
Added top-down reuse

### DIFF
--- a/lib/eco/incparser/astree.py
+++ b/lib/eco/incparser/astree.py
@@ -152,6 +152,7 @@ class Node(object):
             if not node.parent:
                 break
             if node.parent.has_changes():
+                node.parent.nested_changes = True
                 break
             node = node.parent
             node.nested_changes = True

--- a/lib/eco/treemanager.py
+++ b/lib/eco/treemanager.py
@@ -1880,6 +1880,7 @@ class TreeManager(object):
             parser.prev_version = self.version
             parser.reference_version = self.reference_version
             parser.inc_parse()
+            parser.top_down_reuse()
             self.save_current_version(postparse=True) # save post parse tree
             if parser.last_status == True:
                 self.reference_version = self.version


### PR DESCRIPTION
This commit adds Wagner's top-down reuse to Eco. Top-down reuse happens after parsing has finished and allows the reusing of nodes that bottom-up reuse can't find.

This is especially useful for empty nonterminals which, due to a bug in the retainability algorithm, can't currently be optimistically shifted during parsing and have to be recreated.