### PR TITLE
Properly set exists flags and calculate node position

### DIFF
--- a/lib/eco/incparser/astree.py
+++ b/lib/eco/incparser/astree.py
@@ -584,10 +584,6 @@ class TextNode(Node):
             return self.get_attr("changed", version) or self.get_attr("nested_changes", version)
         return self.changed or self.nested_changes
 
-    def does_exist(self):
-        # XXX isn't it also either new or reused?
-        return self.exists
-
     def has_errors(self):
         return self.nested_errors or self.local_error
 

--- a/lib/eco/test/test_eco.py
+++ b/lib/eco/test/test_eco.py
@@ -821,7 +821,7 @@ class Test_Indentation(Test_Python):
         self.treemanager.key_delete()
 
     def test_indentation_stresstest_bug_retain(self):
-        # In the `pass2` method `textlength` needs to check the yield of the
+        # In the `pass1` method `textlength` needs to check the yield of the
         # previous version of the program. Wagner's thesis uses the current
         # version, which is limited by the error and thus can never have a
         # greater yield than the location of error
@@ -864,7 +864,8 @@ class Test_Indentation(Test_Python):
         self.move(DOWN, 17)
         self.move(RIGHT, 11)
         self.treemanager.key_backspace()
-        #assert False
+        # This is the part where the bug is introduced, leading to an
+        # error later on
         self.treemanager.cursor_reset()
         self.move(DOWN, 14)
         self.move(RIGHT, 2)

--- a/lib/eco/treemanager.py
+++ b/lib/eco/treemanager.py
@@ -955,6 +955,12 @@ class TreeManager(object):
                 self.save_and_textlen_rec(c, postparse)
             node.calc_textlength()
             node.save(self.version)
+            # Make sure that all nodes are always marked as non-existent before
+            # a new parse. This way only parsed subtrees are marked as exists,
+            # and we avoid retaining not yet parsed subtrees. However, not yet
+            # marked subtrees shouldn't end up in the retain part in the first
+            # place. But due to Wagner using current_version instead of
+            # previous_version in pass1 this can happen.
             node.exists = False
 
     def key_home(self, shift=False):


### PR DESCRIPTION
This commit fixes a few inconsistencies with the node.exists-flag which can cause problems with the retain algorithms. This commit also fixes the position calculation used for same_text_pos which was inaccurate. We can't use the position from the history as changing a token at the beginning of the file we'd have to update the positions of all other tokens in the entire tree. Luckily, we only need the position within the `same_text_pos` function. When we reach that function we will have visited all changed nodes up to that point so we can calculate their position on the fly during `pass1`.