### PR TITLE
Limit automatic language box detection

### DIFF
--- a/lib/eco/astanalyser.py
+++ b/lib/eco/astanalyser.py
@@ -303,7 +303,7 @@ class AstAnalyser(object):
     def get_lboxanalyser(self, root):
         if not self.parsers:
             return
-        for parser, lexer, lang, analyser in self.parsers:
+        for parser, lexer, lang, analyser, _ in self.parsers:
             if parser.previous_version.parent is root:
                 return analyser
 

--- a/lib/eco/grammars/grammars.py
+++ b/lib/eco/grammars/grammars.py
@@ -49,6 +49,8 @@ class EcoFile(object):
         self.alts = {}
         self.included_langs = set()
         self.extract = None
+        self.auto_include = None
+        self.auto_exclude = None
 
     def load(self, buildlexer=True):
         from grammar_parser.bootstrap import BootstrapParser
@@ -102,6 +104,26 @@ class EcoFile(object):
 
     def change_start(self, name):
         self.extract = name
+
+    def set_auto_include(self, lang, tokentype):
+        if self.auto_include is None:
+            self.auto_include = {}
+        self.auto_include[lang] = tokentype
+
+    def set_auto_exclude(self, lang, tokentype):
+        if self.auto_include is not None:
+            print "Warning: Inclusion and exclusion rules may conflict! Exclusion rules will be ignored."
+            return
+        if self.auto_exclude is None:
+            self.auto_exclude = {}
+        self.auto_exclude[lang] = tokentype
+
+    def auto_allows(self, lang, tokentype):
+        if self.auto_include and self.auto_include.has_key(lang):
+            return tokentype in self.auto_include[lang]
+        if self.auto_exclude and self.auto_exclude.has_key(lang):
+            return tokentype not in self.auto_exclude[lang]
+        return True
 
     def __str__(self):
         return self.name

--- a/lib/eco/treemanager.py
+++ b/lib/eco/treemanager.py
@@ -2063,7 +2063,7 @@ class TreeManager(object):
         outer_root = lbox.get_root()
         outer_lang = outer_root.name
         outer_parser, outer_lexer = lang_dict[outer_lang].load() # get preloaded one
-        r = IncrementalRecognizer(outer_parser.syntaxtable, outer_lexer.lexer, outer_lang)
+        r = IncrementalRecognizer(outer_parser.syntaxtable, outer_lexer.lexer, outer_lang, None)
         r.preparse(outer_root, lbox)
         result =  r.parse(lbox.symbol.ast.children[0].next_term, lbox.next_term, status)
         return result


### PR DESCRIPTION
This PR adds options to limit the automatic detection of language boxes to specific tokens. This is used
to avoid that compositions with HTML detect boxes everywhere, since any text is valid in HTML.

One remaining question is, if we should reverse the way these tokens are defined, e.g. instead of specifying what CAN be allowed, we need to specify what CANNOT be allowed. For HTML this would make defining the composition a lot easier as we could just disallow the `TEXT` token. However, for other languages it might be easier to define what is allowed.