### PR TITLE
Fix lboxsubmenu

### DIFF
--- a/lib/eco/grammars/grammars.py
+++ b/lib/eco/grammars/grammars.py
@@ -258,7 +258,7 @@ languages = [calc,
              regex,
              javapy]
 newfile_langs = [java, javasql, javasqlchemical, php, phppython, python, pythonhtmlsql, pythonhtmlsqlsingle, pythonprolog, prolog, sql, sqlfull, html, htmlpythonsql, pythonipython, calc, ruby, simplelang, rubysl, rubyjs, javascript, regex, javapy]
-submenu_langs = [java, javasqlchemical, java_expr, php, phppython, python, pythonhtmlsql, pythonprolog, pythonphp, python_expr, prolog, sql, sql_single, sql_ref_java, html, htmlpythonsql, img, chemical, ipython, ruby, simplelang, javascript, rubysl, rubyjs]
+submenu_langs = [java, javasqlchemical, java_expr, php, phppython, python, pythonhtmlsql, pythonprolog, pythonphp, python_expr, python_method, prolog, sql, sql_single, sql_ref_java, html, htmlpythonsql, img, chemical, ipython, ruby, simplelang, javascript, rubysl, rubyjs]
 
 lang_dict = {}
 for l in languages:

--- a/lib/eco/incparser/incparser.py
+++ b/lib/eco/incparser/incparser.py
@@ -913,11 +913,7 @@ class IncParser(object):
         return AST(root)
 
     def get_next_possible_symbols(self, state_id):
-        l = set()
-        for (state, symbol) in self.syntaxtable.table.keys():
-            if state == state_id:
-                l.add(symbol)
-        return l
+        return self.syntaxtable.table[state_id].iterkeys()
 
     def get_next_symbols_list(self, state = -1):
         if state == -1:


### PR DESCRIPTION
1) Fix language box menus broken by the syntaxtable changes in 769df19.
2) Add Python method subgrammar to the language box menu (needed by Java+Python composition)