### PR TITLE
Fix error recovery bug in Eco grammar

### DIFF
--- a/lib/eco/incparser/incparser.py
+++ b/lib/eco/incparser/incparser.py
@@ -107,6 +107,7 @@ class IncParser(object):
         self.autolboxes = None
         self.autodetector = None
         self.option_autolbox_find = False
+        self.lang = None
 
     def is_valid_symbol(self, state, token):
         return self.syntaxtable.lookup(state, token) is not None


### PR DESCRIPTION
When editing the Ecogrammar grammar and an error occurs, out-of-context
analysis fails due to the incparser instance having no `lang` attribute
(for all other grammars based on EcoFile this is not the case). This
commit fixes this by setting `lang` to None by default.