### PR TITLE
Various fixes

### DIFF
--- a/lib/eco/eco.py
+++ b/lib/eco/eco.py
@@ -1319,6 +1319,9 @@ class Window(QtGui.QMainWindow):
                 self.ui.hud_heat_map_button.setChecked(True)
             else:
                 self.ui.hud_off_button.setChecked(True)
+            tm = ed_tab.editor.tm
+            if self.pgviewer:
+                self.pgviewer.update(tm.main_lbox, tm.version, tm.get_max_version())
         else:
             self.toggle_menu(False)
         self.btReparse()

--- a/lib/eco/incparser/incparser.py
+++ b/lib/eco/incparser/incparser.py
@@ -245,6 +245,12 @@ class IncParser(object):
                     la = self.left_breakdown(la)
                 else:
                     if USE_OPT:
+                        if not la.children:
+                            # Since we are not allowed to optshift empty
+                            # nonterminals due to the retainbug, we can just
+                            # skip this node immediately.
+                            la = self.left_breakdown(la)
+                            continue
                         goto = self.syntaxtable.lookup(self.current_state, la.symbol)
                         # Only opt-shift if the nonterminal has children to
                         # avoid a bug in the retainability algorithm. See

--- a/lib/eco/pgviewer.py
+++ b/lib/eco/pgviewer.py
@@ -4,6 +4,7 @@ from dotviewer import drawgraph
 from grammar_parser.gparser import MagicTerminal
 from threading import Thread
 from grammar_parser.bootstrap import AstNode, ListNode
+from incparser.astree import BOS, EOS
 
 class PGThread(Thread):
 
@@ -119,7 +120,8 @@ class PGViewer(object):
 
         try:
             if node.get_attr("local_error", self.version):
-                dotnode.set('color','red')
+                if not (isinstance(node, EOS) or isinstance(node, BOS)):
+                    dotnode.set('color','red')
         except AttributeError:
             pass
 

--- a/lib/eco/pgviewer.py
+++ b/lib/eco/pgviewer.py
@@ -56,6 +56,11 @@ class PGViewer(object):
             self.showast = self.showast ^ True
             self.refresh(self.version)
 
+    def update(self, root, version, max_version):
+        self.root = root
+        self.version = version
+        self.max_version = max_version
+
     def refresh(self, version):
         if self.is_alive():
             if version > 0 and version <= self.max_version:


### PR DESCRIPTION
This PR contains the following 3 fixes:

- 553560e fixes the parsetree viewer which previously wouldn't update to the correct parsetree when switching to a different tab within the editor
- 0657a5c is another small change in parsetree viewer that doesn't show BOS/EOS nodes as containing errors. This is only an aesthetic change which avoids confusion when looking at the parse tree.
- f2f5565 fixes error recovery. The fix for the retain bug unfortunately broke out-of-context analysis whose results weren't integrated into the parsetree anymore (even if it succeeded). The remedy for this was to skip empty nonterminals sooner rather than later.