### PR TITLE
Install PyQt4 dependecy via apt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,21 +7,12 @@ virtualenv:
 cache:
   directories:
     - lib/eco/pickle
-    - downloads/
 
-install:
-    - "pip install py"
-    - mkdir -p downloads
-    - test -f downloads/sip-4.19.3/ChangeLog || curl -L -o downloads/sip.tar.gz http://sourceforge.mirrorservice.org/p/py/pyqt/sip/sip-4.19.3/sip-4.19.3.tar.gz
-    - test -f downloads/PyQt4_gpl_x11-4.12.1/ChangeLog || curl -L -o downloads/pyqt.tar.gz http://sourceforge.mirrorservice.org/p/py/pyqt/PyQt4/PyQt-4.12.1/PyQt4_gpl_x11-4.12.1.tar.gz
-    - test -f downloads/sip-4.19.3/ChangeLog || tar xzf downloads/sip.tar.gz -C downloads --skip-old-files
-    - test -f downloads/PyQt4_gpl_x11-4.12.1/ChangeLog || tar xzf downloads/pyqt.tar.gz -C downloads --skip-old-files
-    - cd downloads/sip-4.19.3
-    - test -f siplib/sip.so || (python configure.py && sudo make)
-    - sudo make install && cd ../../
-    - cd downloads/PyQt4_gpl_x11-4.12.1
-    - test -f QtCore/QtCore.so || (python configure.py --confirm-license && sudo make)
-    - sudo make install && cd ../../
+addons:
+  apt:
+    packages:
+    - python-sip
+    - python-qt4
 
 script:
 - cd lib/eco;


### PR DESCRIPTION
Until now we had to build PyQt4 manually since on Travis virtualenv didn't
have access to system packages. This seemed to have changed now so we can go
back to installing these dependecies via apt.