### PR TITLE
Fix tabChange when no graph is loaded

### DIFF
--- a/lib/eco/eco.py
+++ b/lib/eco/eco.py
@@ -1303,7 +1303,8 @@ class Window(QtGui.QMainWindow):
     def tabChanged(self, index):
         ed_tab = self.getEditorTab()
         if ed_tab is not None:
-            if ed_tab.editor.tm.get_mainparser().graph:
+            if hasattr(ed_tab.editor.tm.get_mainparser(), "graph") and \
+                    ed_tab.editor.tm.get_mainparser().graph:
                 self.ui.actionStateGraph.setEnabled(True)
             else:
                 self.ui.actionStateGraph.setEnabled(False)


### PR DESCRIPTION
When loading a cached grammar, `graph` on `incparser` isn't set and thus
leads to an error when changing tabs. This commit checks for the `graph`
attribute appropriately by using `hasattr`.