### PR TITLE
Find longest match in Lexer.lex method

### DIFF
--- a/lib/eco/treelexer/lexer.py
+++ b/lib/eco/treelexer/lexer.py
@@ -472,19 +472,25 @@ class Lexer(object):
         pm = PatternMatcher()
         self.pos = 0
         result = []
+        progress = 0
         while True:
             lookahead = 0
             oldpos = self.pos
+            tmpresult = ("", None, None)
             for p, n in self.patterns:
                 if pm.match(p, text[self.pos:]):
                     lookahead = max(pm.la, lookahead)
                     value = text[self.pos:self.pos + pm.pos]
                     lookahead = lookahead - len(value)
-                    result.append((value, n, lookahead))
-                    self.pos += pm.pos
+                    if len(value) > len(tmpresult[0]):
+                        tmpresult = (value, n, lookahead)
+                        progress = pm.pos
                     lookahead = 0
                 else:
                     lookahead = max(pm.la, lookahead)
+            if tmpresult[0]:
+                result.append(tmpresult)
+                self.pos += progress
             if self.pos == oldpos:
                 # no more matches
                 if self.pos < len(text):


### PR DESCRIPTION
Though Lexer.lex isn't used in Eco (which uses Lexer.get_token_iter),
the method is still useful if we need to lex input strings rather than
nodes. Previously, however, Lexer.lex returned the first matched token
instead of searching for longer matches. This has been fixed now.

I am currently using this in the language-box experiments to extract SQL, PHP, Java, etc. expressions
from source files.