### PR TITLE
Fix loading of Eco files with errors

### DIFF
--- a/lib/eco/incparser/astree.py
+++ b/lib/eco/incparser/astree.py
@@ -565,7 +565,7 @@ class TextNode(Node):
         return ("new", version) in self.log
 
     def textlength(self, version = None):
-        if version:
+        if version is not None:
             return self.get_attr("textlen", version)
         return self.textlen
 

--- a/lib/eco/jsonmanager.py
+++ b/lib/eco/jsonmanager.py
@@ -76,6 +76,7 @@ class JsonManager(object):
         jsnode["local_error"] = node.local_error
         jsnode["nested_errors"] = node.nested_errors
         jsnode["image_src"] = node.image_src
+        jsnode["textlen"] = node.textlen
 
         children = []
         for c in node.children:
@@ -105,6 +106,7 @@ class JsonManager(object):
         try:
             node.local_error = jsnode["local_error"]
             node.nested_errors = jsnode["nested_errors"]
+            node.textlen = jsnode["textlen"]
         except KeyError:
             pass # Backwards compatibility for old Eco files
         node.image_src = jsnode["image_src"]


### PR DESCRIPTION
Enabling the retain-feature of Wagner's error recovery broke the
loading of Eco files that contain errors. Storing the text-length of
nodes when saving Eco files (and fixing a small bug in the text-length
function) fixes this problem.