### PR TITLE
Try to continue lexing after error

### DIFF
--- a/lib/eco/inclexer/inclexer.py
+++ b/lib/eco/inclexer/inclexer.py
@@ -493,7 +493,6 @@ class IncrementalLexerCF(object):
         pos = 0  # read tokens
         read = 0 # generated tokens
         current_node = node
-        sw = StringWrapper(node, startnode)
         next_token = self.lexer.get_token_iter(node).next
 
         combos = []
@@ -570,6 +569,14 @@ class IncrementalLexerCF(object):
                 else:
                     # There are no part matches so remark the startnode as error
                     startnode.changed = True
+                if not past_startnode:
+                    # When a lexing error occurs before we reached the newly
+                    # inserted node (startnode) try to continue lexing from
+                    # startnode onwards.
+                    # See Test_Relexing::test_newline_after_error
+                    next_token = self.lexer.get_token_iter(startnode).next
+                    past_startnode = True
+                    continue
                 break
 
         if not toks:

--- a/lib/eco/test/test_eco.py
+++ b/lib/eco/test/test_eco.py
@@ -1232,6 +1232,16 @@ def y():
 
         assert self.parser.last_status is True
 
+    def test_newline_after_error(self):
+        self.reset()
+
+        for c in "   $x=1;\n":
+            self.treemanager.key_normal(c)
+        assert self.parser.last_status is False
+
+        # Check that the node `\n   ` has been split up
+        assert self.treemanager.cursor.node.symbol.name == "   "
+
 class Test_NestedLboxWithIndentation():
     def setup_class(cls):
         parser, lexer = calc.load()


### PR DESCRIPTION
When an error occurs during lexing, we abort lexing and leave the tokens
in the tree as is. However, this can lead to tokens containing newlines
to not be split up (which is necessary for Eco to function properly).
We can fix this problem, by ensure that even if an error occurs before
a newly inserted token, at the very least that token is relexed, which
ensures that newly inserted newlines are broken up properly.