### PR TITLE
Load external compositions

### DIFF
--- a/lib/eco/compositions/javaphp.json
+++ b/lib/eco/compositions/javaphp.json
@@ -1,0 +1,21 @@
+{
+    "name": "Java+PHP",
+    "file": "grammars/java15.eco",
+    "subset": null,
+    "compositions": [
+        {
+            "name": "PHP func",
+            "file": "grammars/php.eco",
+            "subset": "class_statement",
+            "location": "method_declaration",
+            "compositions": []
+        },
+        {
+            "name": "PHP expr",
+            "file": "grammars/php.eco",
+            "subset": "expr_without_variable",
+            "location": "unary_expression",
+            "compositions": []
+        }
+    ]
+}

--- a/lib/eco/eco.py
+++ b/lib/eco/eco.py
@@ -526,6 +526,9 @@ class LanguageView(QtGui.QDialog):
         self.ui = Ui_LanguageDialog()
         self.ui.setupUi(self)
 
+        if len(newfile_langs) == 0:
+            return
+
         # categorize languages
         d = {}
         self.d = d
@@ -1148,21 +1151,10 @@ class Window(QtGui.QMainWindow):
 
     def load_composition(self, filename):
         import json
-        from grammars import grammars
+        from grammars.grammars import create_grammar_from_config
         with open(filename) as f:
-            comp = json.load(f)
-            print(comp)
-            main = grammars.EcoFile(comp["name"], comp["file"], "")
-            main.auto_limit_new = True
-            for c in comp["compositions"]:
-                sub = grammars.EcoFile(c["name"], c["file"], "")
-                if c["subset"]:
-                    sub.change_start(c["subset"])
-                main.add_alternative(c["location"], sub)
-                grammars.add_lang(sub, False, True)
-                lang_dict[sub.name] = sub
-            grammars.add_lang(main, True, False)
-            lang_dict[main.name] = main
+            cfg = json.load(f)
+            create_grammar_from_config(cfg, filename)
 
     def savefile(self):
         ed = self.getEditorTab()

--- a/lib/eco/grammars/include/basiccalc.json
+++ b/lib/eco/grammars/include/basiccalc.json
@@ -1,0 +1,6 @@
+{
+    "name": "Basic Calculator",
+    "file": "grammars/basiccalc.eco",
+    "base": "Calc",
+    "visibility": ["newfile"]
+}

--- a/lib/eco/grammars/include/ecogrammar.json
+++ b/lib/eco/grammars/include/ecogrammar.json
@@ -1,0 +1,6 @@
+{
+    "name": "Eco Grammar (Ecofile)",
+    "file": "grammars/eco_grammar.eco",
+    "base": "Grammar",
+    "visibility": ["newfile"]
+}

--- a/lib/eco/grammars/include/html.json
+++ b/lib/eco/grammars/include/html.json
@@ -1,0 +1,6 @@
+{
+    "name": "HTML",
+    "file": "grammars/html.eco",
+    "base": "Html",
+    "visibility": ["newfile", "submenu"]
+}

--- a/lib/eco/grammars/include/htmlpythonsql.json
+++ b/lib/eco/grammars/include/htmlpythonsql.json
@@ -1,0 +1,29 @@
+{
+    "name": "HTML + Python + SQL",
+    "file": "grammars/html.eco",
+    "base": "Html",
+    "visibility": ["newfile", "submenu"],
+    "compositions": [
+        {
+            "location": "element",
+            "name": "Python + HTML + SQL",
+            "file": "grammars/python275.eco",
+            "base": "Python",
+            "visibility": ["submenu"],
+            "compositions": [
+                {
+                    "location": "atom",
+                    "name": "HTML"
+                },
+                {
+                    "location": "atom",
+                    "name": "SQL (Dummy)"
+                }
+            ]
+        },
+        {
+            "location": "attribute_value",
+            "name": "Image"
+        }
+    ]
+}

--- a/lib/eco/grammars/include/image.json
+++ b/lib/eco/grammars/include/image.json
@@ -1,0 +1,6 @@
+{
+    "name": "Image",
+    "file": "grammars/img.eco",
+    "base": "Image",
+    "visibility": ["submenu"]
+}

--- a/lib/eco/grammars/include/ipython.json
+++ b/lib/eco/grammars/include/ipython.json
@@ -1,0 +1,6 @@
+{
+    "name": "IPython",
+    "file": "grammars/python275.eco",
+    "base": "IPython",
+    "visibility": ["submenu"]
+}

--- a/lib/eco/grammars/include/java15.json
+++ b/lib/eco/grammars/include/java15.json
@@ -1,0 +1,6 @@
+{
+    "name": "Java",
+    "file": "grammars/java15.eco",
+    "base": "Java",
+    "visibility": ["newfile", "submenu"]
+}

--- a/lib/eco/grammars/include/javaphp.json
+++ b/lib/eco/grammars/include/javaphp.json
@@ -1,20 +1,27 @@
 {
     "name": "Java+PHP",
     "file": "grammars/java15.eco",
+    "base": "Java",
     "subset": null,
+    "visibility": ["newfile"],
+    "limit_historic_tokens": false,
     "compositions": [
         {
             "name": "PHP func",
             "file": "grammars/php.eco",
+            "base": "Php",
             "subset": "class_statement",
             "location": "method_declaration",
+            "visibility": ["submenu"],
             "compositions": []
         },
         {
             "name": "PHP expr",
             "file": "grammars/php.eco",
+            "base": "Php",
             "subset": "expr_without_variable",
             "location": "unary_expression",
+            "visibility": ["submenu"],
             "compositions": []
         }
     ]

--- a/lib/eco/grammars/include/javapython.json
+++ b/lib/eco/grammars/include/javapython.json
@@ -1,0 +1,29 @@
+{
+    "name": "Java + Python",
+    "file": "grammars/java15.eco",
+    "base": "Java",
+    "visibility": ["newfile"],
+    "limit_historic_tokens": true,
+    "compositions": [
+        {
+            "location": "unary_expression",
+            "name": "Python expression"
+        },
+        {
+            "location": "class_body_declaration",
+            "name": "Python method",
+            "file": "grammars/python275.eco",
+            "base": "Python",
+            "subset": "funcdef",
+            "visibility": ["submenu"]
+        },
+        {
+            "location": "class_body_declaration",
+            "name": "Python class",
+            "file": "grammars/python275.eco",
+            "base": "Python",
+            "subset": "classdef",
+            "visibility": ["submenu"]
+        }
+    ]
+}

--- a/lib/eco/grammars/include/javascript.json
+++ b/lib/eco/grammars/include/javascript.json
@@ -1,0 +1,6 @@
+{
+    "name": "JavaScript",
+    "file": "grammars/javascript.eco",
+    "base": "JavaScript",
+    "visibility": ["newfile", "submenu"]
+}

--- a/lib/eco/grammars/include/javasqlite.json
+++ b/lib/eco/grammars/include/javasqlite.json
@@ -1,0 +1,14 @@
+{
+    "name": "Java + SQL",
+    "file": "grammars/java15.eco",
+    "base": "Java",
+    "subset": null,
+    "visibility": ["newfile"],
+    "limit_historic_tokens": false,
+    "compositions": [
+        {
+            "location": "unary_expression",
+            "name": "SQLite"
+        }
+    ]
+}

--- a/lib/eco/grammars/include/lua.json
+++ b/lib/eco/grammars/include/lua.json
@@ -1,0 +1,6 @@
+{
+    "name": "Lua 5.3",
+    "file": "grammars/lua5_3.eco",
+    "base": "Lua",
+    "visibility": ["newfile", "submenu"]
+}

--- a/lib/eco/grammars/include/php.json
+++ b/lib/eco/grammars/include/php.json
@@ -1,0 +1,6 @@
+{
+    "name": "PHP",
+    "file": "grammars/php.eco",
+    "base": "Php",
+    "visibility": ["newfile", "submenu"]
+}

--- a/lib/eco/grammars/include/phppython.json
+++ b/lib/eco/grammars/include/phppython.json
@@ -1,0 +1,30 @@
+{
+    "name": "PHP + Python",
+    "file": "grammars/php.eco",
+    "base": "Php",
+    "visibility": ["newfile", "submenu"],
+    "custom_namebinding": "phppython.nb",
+    "compositions": [
+        {
+            "location": "top_statement",
+            "name": "Python + PHP"
+        },
+        {
+            "location": "class_statement",
+            "name": "Python + PHP"
+        },
+        {
+            "location": "expr",
+            "name": "Python + PHP"
+        },
+        {
+            "location": "expr",
+            "name": "Python expression",
+            "file": "grammars/python275.eco",
+            "base": "Python",
+            "subset": "simple_stmt",
+            "visibility": ["submenu"]
+        }
+
+    ]
+}

--- a/lib/eco/grammars/include/prolog.json
+++ b/lib/eco/grammars/include/prolog.json
@@ -1,0 +1,6 @@
+{
+    "name": "Prolog",
+    "file": "grammars/prolog.eco",
+    "base": "Prolog",
+    "visibility": ["newfile", "submenu"]
+}

--- a/lib/eco/grammars/include/python275.json
+++ b/lib/eco/grammars/include/python275.json
@@ -1,0 +1,6 @@
+{
+    "name": "Python 2.7.5",
+    "file": "grammars/python275.eco",
+    "base": "Python",
+    "visibility": ["newfile", "submenu"]
+}

--- a/lib/eco/grammars/include/pythonipython.json
+++ b/lib/eco/grammars/include/pythonipython.json
@@ -1,0 +1,12 @@
+{
+    "name": "Python + IPython",
+    "file": "grammars/python275.eco",
+    "base": "Python",
+    "visibility": ["newfile"],
+    "compositions": [
+        {
+            "location": "atom",
+            "name": "IPython"
+        }
+    ]
+}

--- a/lib/eco/grammars/include/pythonphp.json
+++ b/lib/eco/grammars/include/pythonphp.json
@@ -1,0 +1,12 @@
+{
+    "name": "Python + PHP",
+    "file": "grammars/python275.eco",
+    "base": "Python",
+    "visibility": ["newfile", "submenu"],
+    "compositions": [
+        {
+            "location": "atom",
+            "name": "PHP + Python"
+        }
+    ]
+}

--- a/lib/eco/grammars/include/pythonprolog.json
+++ b/lib/eco/grammars/include/pythonprolog.json
@@ -1,0 +1,12 @@
+{
+    "name": "Python + Prolog",
+    "file": "grammars/python275.eco",
+    "base": "Python",
+    "visibility": ["newfile"],
+    "compositions": [
+        {
+            "name": "Prolog",
+            "location": "atom"
+        }
+    ]
+}

--- a/lib/eco/grammars/include/rubyjavascript.json
+++ b/lib/eco/grammars/include/rubyjavascript.json
@@ -1,0 +1,12 @@
+{
+    "name": "Ruby + JavaScript",
+    "file": "grammars/ruby.eco",
+    "base": "Ruby",
+    "visibility": ["newfile"],
+    "compositions": [
+        {
+            "location": "top_stmt",
+            "name": "JavaScript"
+        }
+    ]
+}

--- a/lib/eco/grammars/include/rubysl.json
+++ b/lib/eco/grammars/include/rubysl.json
@@ -1,0 +1,12 @@
+{
+    "name": "Ruby + SimpleLanguage",
+    "file": "grammars/ruby.eco",
+    "base": "Ruby",
+    "visibility": ["newfile"],
+    "compositions": [
+        {
+            "location": "top_stmt",
+            "name": "SimpleLanguage"
+        }
+    ]
+}

--- a/lib/eco/grammars/include/scopinggrammar.json
+++ b/lib/eco/grammars/include/scopinggrammar.json
@@ -1,0 +1,6 @@
+{
+    "name": "Scoping Rules (Ecofile)",
+    "file": "grammars/scoping_grammar.eco",
+    "base": "Scoping",
+    "visibility": []
+}

--- a/lib/eco/grammars/include/simplelang.json
+++ b/lib/eco/grammars/include/simplelang.json
@@ -1,0 +1,6 @@
+{
+    "name": "SimpleLanguage",
+    "file": "grammars/simplelang.eco",
+    "base": "SimpleLanguage",
+    "visibility": ["newfile", "submenu"]
+}

--- a/lib/eco/grammars/include/sql.json
+++ b/lib/eco/grammars/include/sql.json
@@ -1,0 +1,6 @@
+{
+    "name": "SQL (Dummy)",
+    "file": "grammars/sql.eco",
+    "base": "Sql",
+    "visibility": ["newfile", "submenu"]
+}

--- a/lib/eco/grammars/include/sqlite.json
+++ b/lib/eco/grammars/include/sqlite.json
@@ -1,0 +1,6 @@
+{
+    "name": "SQLite",
+    "file": "grammars/sqlite.eco",
+    "base": "Sql",
+    "visibility": ["newfile", "submenu"]
+}

--- a/lib/eco/grammars/include/sqlstmt.json
+++ b/lib/eco/grammars/include/sqlstmt.json
@@ -1,0 +1,7 @@
+{
+    "name": "SQL Statement",
+    "file": "grammars/sql.eco",
+    "base": "Sql",
+    "subset": "sql_line",
+    "visibility": ["submenu"]
+}

--- a/lib/eco/inclexer/test/test_inclexer.py
+++ b/lib/eco/inclexer/test/test_inclexer.py
@@ -21,7 +21,7 @@
 
 from inclexer.inclexer import IncrementalLexerCF
 from incparser.astree import AST
-from grammars.grammars import calc
+from grammars.grammars import lang_dict
 from incparser.astree import TextNode, BOS, EOS, MultiTextNode
 from grammar_parser.gparser import Terminal, Nonterminal, MagicTerminal
 
@@ -29,6 +29,7 @@ import pytest
 from treelexer.lexer import LexingError, lbph
 
 IncrementalLexer = IncrementalLexerCF
+calc = lang_dict["Basic Calculator"]
 
 class Test_IncrementalLexer:
 

--- a/lib/eco/incparser/test/test_incparser2.py
+++ b/lib/eco/incparser/test/test_incparser2.py
@@ -21,13 +21,15 @@
 
 from incparser.incparser import IncParser
 from inclexer.inclexer import IncrementalLexer
-from grammars.grammars import calc, java
+from grammars.grammars import lang_dict
 from grammar_parser.plexer import PriorityLexer
 from grammar_parser.gparser import Terminal, Nonterminal
 from incparser.astree import TextNode, BOS, EOS, FinishSymbol
 
 N = Nonterminal
 T = Terminal
+calc = lang_dict["Basic Calculator"]
+java = lang_dict["Java"]
 
 class Test_IncrementalParser:
 

--- a/lib/eco/test/javasqldummy.json
+++ b/lib/eco/test/javasqldummy.json
@@ -1,0 +1,25 @@
+{
+    "name": "Test grammar: Java + SQLDummy ref. Java",
+    "file": "grammars/java15.eco",
+    "base": "Java",
+    "visibility": ["newfile"],
+    "compositions": [
+        {
+            "location": "unary_expression",
+            "name": "SQL ref. Java",
+            "file": "grammars/sql.eco",
+            "base": "Sql",
+            "visibility": ["submenu"],
+            "compositions": [
+                {
+                    "location": "y_condition",
+                    "name": "Java expression",
+                    "file": "grammars/sql.eco",
+                    "base": "Java",
+                    "subset": "expression",
+                    "visibility": ["submenu"]
+                }
+            ]
+        }
+    ]
+}

--- a/lib/eco/test/test_eco.py
+++ b/lib/eco/test/test_eco.py
@@ -19,7 +19,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-from grammars.grammars import calc, java, python, lua, Language, sql, pythonprolog, lang_dict, phppython, pythonphp, pythonhtmlsql, html
+from grammars.grammars import lang_dict, Language
 from treemanager import TreeManager
 from incparser.incparser import IncParser
 from inclexer.inclexer import IncrementalLexer, IncrementalLexerCF
@@ -33,6 +33,18 @@ import programs
 
 import pytest
 slow = pytest.mark.slow
+
+
+calc = lang_dict["Basic Calculator"]
+java = lang_dict["Java"]
+python = lang_dict["Python 2.7.5"]
+lua = lang_dict["Lua 5.3"]
+sql = lang_dict["SQL (Dummy)"]
+pythonprolog = lang_dict["Python + Prolog"]
+phppython = lang_dict["PHP + Python"]
+pythonphp = lang_dict["Python + PHP"]
+pythonhtmlsql = lang_dict["Python + HTML + SQL"]
+html = lang_dict["HTML"]
 
 if pytest.config.option.log:
     import logging
@@ -4521,12 +4533,22 @@ class Test_TopDownReuse(Test_Python):
         assert E is E2
         assert Y is Y2
 
-from grammars.grammars import sql_single, javapy, javasqlchemical, javasql
+sql_single = lang_dict["SQL Statement"]
+javapy = lang_dict["Java + Python"]
+javasql = lang_dict["Java + SQL"]
+javasqlchemical = javasql
 
 # Add some more compositions that we only need inside the test environment
 pythonsql = EcoFile("Python + SQL", "grammars/python275.eco", "Python")
 pythonsql.add_alternative("atom", sql_single)
 lang_dict[pythonsql.name] = pythonsql
+
+import json
+from grammars.grammars import create_grammar_from_config
+with open("test/javasqldummy.json") as f:
+    cfg = json.load(f)
+    javasql2_name = create_grammar_from_config(cfg, "test/javasqldummy.json")
+    javasqlchemical = lang_dict[javasql2_name]
 
 class Test_AutoLanguageBoxDetection():
 

--- a/lib/eco/test/test_grammars.py
+++ b/lib/eco/test/test_grammars.py
@@ -1,5 +1,7 @@
-from grammars.grammars import java
+from grammars.grammars import lang_dict
 from treemanager import TreeManager
+
+java = lang_dict["Java"]
 
 class Test_Java:
     def setup_class(cls):

--- a/lib/eco/test/test_multitextnode.py
+++ b/lib/eco/test/test_multitextnode.py
@@ -1,10 +1,14 @@
-from grammars.grammars import calc, python, php, lang_dict
+from grammars.grammars import lang_dict
 from treemanager import TreeManager
 from grammar_parser.gparser import MagicTerminal
 from utils import KEY_UP as UP, KEY_DOWN as DOWN, KEY_LEFT as LEFT, KEY_RIGHT as RIGHT
 from grammars.grammars import EcoFile
 
 import pytest
+
+calc = lang_dict["Basic Calculator"]
+python = lang_dict["Python 2.7.5"]
+php = lang_dict["PHP"]
 
 if pytest.config.option.log:
     import logging


### PR DESCRIPTION
REQUIRES REBASE AFTER MERGING #237 

This commit allows us to easily create compositions and load them via
json files into Eco. An example composition of Java and PHP can be found
in compositions/javaphp.json

We might want to use this to create all our compositions and use it to replace all the compositions in `grammars/grammar.py`, as it allows users to easily add compositions without having to edit the Eco source. We can either do this in a separate PR or in this one.