### PR TITLE
Fix text-search in Eco to scroll to correct location

### DIFF
--- a/lib/eco/eco.py
+++ b/lib/eco/eco.py
@@ -1027,7 +1027,7 @@ class Window(QtGui.QMainWindow):
             self.getEditor().tm.find_text(text)
             self.getEditor().update()
             self.btReparse([])
-            self.getEditorTab().keypress()
+            self.getEditorTab().keypress(center=True)
 
     def find_next(self):
         text = self.finddialog.getText()

--- a/lib/eco/treemanager.py
+++ b/lib/eco/treemanager.py
@@ -767,7 +767,7 @@ class TreeManager(object):
 
     def find_text(self, text):
         startnode = self.cursor.node
-        node = self.cursor.node.next_term
+        node = self.cursor.node.next_terminal()
         line = self.cursor.line
         index = -1
         while node is not self.cursor.node:
@@ -792,7 +792,7 @@ class TreeManager(object):
 
             if node.symbol.name == "\r":
                 line += 1
-            node = node.next_term
+            node = node.next_terminal()
         if index > -1:
             self.cursor.line = line
             self.cursor.node = node


### PR DESCRIPTION
Introducing multitext nodes broke the editors text-search in that
it didn't properly scroll to the location of the search result.
The reason was that the search ignored multitext nodes (e.g. comments)
and thus missed some newlines contained within them. Using the method
`next_terminal` (which already knows about multitext nodes) fixes this.