### PR TITLE
Fix cursor on strings

### DIFF
--- a/lib/eco/grammar_parser/test/test_bootstrap.py
+++ b/lib/eco/grammar_parser/test/test_bootstrap.py
@@ -161,7 +161,8 @@ class Test_Bootstrapping(object):
     def test_error(self):
         bootstrap = BootstrapParser()
         test_grammar = """S ::= A {If(child1=#1, child2=[#3, #4]}; %% a:\"a\""""
-        py.test.raises(Exception, "bootstrap.parse(test_grammar)")
+        with py.test.raises(Exception):
+            bootstrap.parse(test_grammar)
 
     def test_simple(self):
         bootstrap = BootstrapParser()

--- a/lib/eco/test/conftest.py
+++ b/lib/eco/test/conftest.py
@@ -4,7 +4,7 @@ def pytest_addoption(parser):
         help="ONLY run slow tests")
     parser.addoption("--runslow", action="store_true",
         help="run slow tests")
-    parser.addoption("--log", action="store_true",
+    parser.addoption("--logs", action="store_true",
         help="print debug logs")
 
 def pytest_runtest_setup(item):
@@ -13,3 +13,8 @@ def pytest_runtest_setup(item):
             pytest.skip("need --runslow option to run")
     elif 'slow' in item.keywords and not item.config.getoption("--runslow"):
         pytest.skip("need --runslow option to run")
+
+def pytest_configure(config):
+    if config.getoption('--logs'):
+        import logging
+        logging.getLogger().setLevel(logging.DEBUG)

--- a/lib/eco/test/test_eco.py
+++ b/lib/eco/test/test_eco.py
@@ -1493,6 +1493,8 @@ class Test_Java:
     def move(self, direction, times):
         for i in range(times): self.treemanager.cursor_movement(direction)
 
+class Test_JavaBugs(Test_Java):
+
     def test_incparse_optshift_bug(self):
         prog = """class Test {\r    public static void main() {\r        String y = z;\r    }\r}"""
         for c in prog:
@@ -1505,6 +1507,22 @@ class Test_Java:
         for c in "int x = 1;":
             self.treemanager.key_normal(c)
         assert self.parser.last_status == True
+
+    def test_cursor_jumping_bug(self):
+        self.reset()
+        prog = "x = 1  + 2"
+        for c in prog:
+            self.treemanager.key_normal(c)
+        self.treemanager.key_home()
+        self.treemanager.key_cursors(RIGHT)
+        self.treemanager.key_cursors(RIGHT)
+        self.treemanager.key_cursors(RIGHT)
+        self.treemanager.key_cursors(RIGHT)
+        self.treemanager.key_normal("'")
+        self.treemanager.key_cursors(RIGHT)
+        self.treemanager.key_cursors(RIGHT)
+        self.treemanager.key_normal("'")
+        assert self.treemanager.cursor.node.symbol.name == "'1 '"
 
 class Test_Lua:
     def setup_class(cls):

--- a/lib/eco/test/test_eco.py
+++ b/lib/eco/test/test_eco.py
@@ -46,10 +46,6 @@ pythonphp = lang_dict["Python + PHP"]
 pythonhtmlsql = lang_dict["Python + HTML + SQL"]
 html = lang_dict["HTML"]
 
-if pytest.config.option.log:
-    import logging
-    logging.getLogger().setLevel(logging.DEBUG)
-
 class Test_Typing:
 
     def setup_class(cls):

--- a/lib/eco/test/test_multitextnode.py
+++ b/lib/eco/test/test_multitextnode.py
@@ -10,10 +10,6 @@ calc = lang_dict["Basic Calculator"]
 python = lang_dict["Python 2.7.5"]
 php = lang_dict["PHP"]
 
-if pytest.config.option.log:
-    import logging
-    logging.getLogger().setLevel(logging.DEBUG)
-
 class Test_MultiTextNode:
 
     def setup_class(cls):


### PR DESCRIPTION
After relexing nodes may have been changed in a way that the node the
cursor is attached too is no longer accurate. Previously we would repair
the cursor by checking if the cursor's current node and the cursor
position mismatched (e.g. the cursor position is larger than the text
length of the node). Unfortunately, it is difficult to determine if a
node's text length has been increased or decreased. This occasionally
resulted in weird cursor jumps when typing.

A much easier and straight forward solution to this problem is to simply
store the current cursor position before relexing and then restore it
afterwards (while taking into account any added newlines). In theory
this approach is slightly slower than the previous method, however there
is no noticeable difference when running the tests.