### PR TITLE
Fix inclexer

### DIFF
--- a/lib/eco/test/test_eco.py
+++ b/lib/eco/test/test_eco.py
@@ -1520,6 +1520,24 @@ class Test_JavaBugs(Test_Java):
         self.treemanager.key_normal("'")
         assert self.treemanager.cursor.node.symbol.name == "'1 '"
 
+    def test_inclexing_bug(self):
+        self.reset()
+        prog = """class C {
+    int x = cur;
+	/*
+	 */
+	/*
+	 */
+    int x = '+';
+}"""
+        self.treemanager.import_file(prog)
+        self.move(DOWN, 1)
+        self.move(RIGHT, 16)
+        self.treemanager.key_backspace()
+        self.treemanager.key_backspace()
+        self.treemanager.key_backspace()
+        self.treemanager.key_normal("'")
+
 class Test_Lua:
     def setup_class(cls):
         parser, lexer = lua.load()

--- a/lib/eco/treelexer/lexer.py
+++ b/lib/eco/treelexer/lexer.py
@@ -222,10 +222,16 @@ class TreePatternMatcher(PatternMatcher):
     def char(self):
         return self.text.symbol.name[self.pos]
 
+    def exists_in_readnodes(self, node):
+        for n in self.read_nodes:
+            if node is n:
+                return True
+        return False
+
     def inc(self):
         self.pos += 1
         if self.text.ismultichild():
-            if self.text.parent not in self.read_nodes:
+            if not self.exists_in_readnodes(self.text.parent):
                 self.read_nodes.append(self.text.parent)
         elif self.read_nodes[-1] is not self.text:
             self.read_nodes.append(self.text)


### PR DESCRIPTION
REQUIRES MERGING OF #240 PLUS REBASE!

The tree lexer (which works on a parse tree instead of a steam of
tokens) needs to remember which nodes it has seen during lexing so that
the incremental lexer can then merge new tokens with these nodes.

When the lexer sees a node and it is not already in the list of seen
nodes, it is added. Unfortunately, the check for this previously used
equality to determine if the node has been seen before, which leads to
errors when two or more equivalent nodes are processed during relexing.
This commit updates the existence check to use identity instead, which
fixes the problem.