### PR TITLE
Improve automatic language boxes

### DIFF
--- a/lib/eco/autolboxdetector.py
+++ b/lib/eco/autolboxdetector.py
@@ -343,6 +343,16 @@ class Recognizer(object):
             else:
                 return False
 
+    def parse_lex_single(self, node):
+        self.tokeniter = self.lexer.get_token_iter(node).next
+        token = self.next_token()
+        while True:
+            if not self.temp_parse(self.state, token):
+                return False
+            token = self.next_token()
+            if self.last_read is not node or type(token) is FinishSymbol:
+                return True
+
 class RecognizerIndent(Recognizer):
 
     def __init__(self, syntaxtable, lexer, lang, outer):
@@ -499,6 +509,9 @@ class IncrementalRecognizer(Recognizer):
             if self.parse_after(follow):
                 return True
         return False
+
+    def parse_lex_single(self, node):
+        return Recognizer.parse_lex_single(self, node)
 
     def parse_until(self, start, end):
         node = start.next_term

--- a/lib/eco/eco.py
+++ b/lib/eco/eco.py
@@ -643,6 +643,7 @@ class Window(QtGui.QMainWindow):
         self.connect(self.ui.actionAutolboxInsert, SIGNAL("triggered()"), self.toggle_insert_autolboxes)
         self.connect(self.ui.actionShow_lspaceview, SIGNAL("triggered()"), self.view_in_lspace)
         self.connect(self.ui.menuChange_language_box, SIGNAL("aboutToShow()"), self.showEditMenu)
+        self.connect(self.ui.actionRemove_language_box, SIGNAL("triggered()"), self.remove_languagebox)
         self.connect(self.ui.menuRecent_files, SIGNAL("aboutToShow()"), self.showRecentFiles)
         self.connect(self.ui.actionInput_log, SIGNAL("triggered()"), self.show_input_log)
 
@@ -800,6 +801,7 @@ class Window(QtGui.QMainWindow):
 
         menu.addMenu(changemenu)
         menu.addMenu(newmenu)
+        menu.addAction(self.ui.actionRemove_language_box)
         menu.addAction(self.ui.actionSelect_next_language_box)
         menu.addSeparator()
         menu.addAction(self.ui.actionCode_complete)
@@ -1011,6 +1013,11 @@ class Window(QtGui.QMainWindow):
 
     def show_lbox_menu(self):
         self.getEditor().showLanguageBoxMenu()
+        self.getEditor().update()
+
+    def remove_languagebox(self):
+        self.getEditor().tm.remove_selected_lbox()
+        self.btReparse([])
         self.getEditor().update()
 
     def show_code_completion(self):
@@ -1460,6 +1467,7 @@ class Window(QtGui.QMainWindow):
         self.ui.actionSelect_all.setEnabled(enabled)
         self.ui.actionFind_next.setEnabled(enabled)
         self.ui.actionAdd_language_box.setEnabled(enabled)
+        self.ui.actionRemove_language_box.setEnabled(enabled)
         self.ui.actionSelect_next_language_box.setEnabled(enabled)
         self.ui.actionAutolboxInsert.setEnabled(enabled)
         self.ui.actionAutolboxFind.setEnabled(enabled)

--- a/lib/eco/editortab.py
+++ b/lib/eco/editortab.py
@@ -26,6 +26,7 @@ from PyQt4.QtGui import *
 
 from nodeeditor import NodeEditor
 from grammars.grammars import Language, EcoGrammar, EcoFile
+from grammar_parser.gparser import MagicTerminal
 
 from incparser.incparser import IncParser
 from inclexer.inclexer import IncrementalLexer
@@ -365,21 +366,28 @@ class AutoLBoxComplete(QFrame):
                 return
             for s, e, l in self.parent().editor.autolboxlines[line]:
                 text = []
-                temp = s
-                while temp is not e:
-                    text.append(temp.symbol.name)
-                    temp = temp.next_term
-                text.append(e.symbol.name)
-                text.append(" : {}".format(l))
+                if type(s.symbol) is MagicTerminal:
+                    temp = s.symbol.ast.children[0].next_term
+                    text = ["Extend to '{}'".format(e.symbol.name)]
+                else:
+                    temp = s
+                    while temp is not e:
+                        text.append(temp.symbol.name)
+                        temp = temp.next_term
+                    text.append(e.symbol.name)
+                    text.append(" : {}".format(l))
                 item = QAction("".join(text), menu)
                 item.setData((s,e,l))
                 menu.addAction(item)
             action = menu.exec_(self.mapToGlobal(event.pos()))
             if action:
                 s, e, l = action.data().toPyObject()
-                self.parent().editor.tm.select_nodes(s, e)
-                langdef = self.parent().editor.tm.get_langdef_from_string(l)
-                self.parent().editor.tm.surround_with_languagebox(langdef)
+                if type(s.symbol) is MagicTerminal:
+                    self.parent().editor.tm.expand_languagebox(s, e, manual=True)
+                else:
+                    self.parent().editor.tm.select_nodes(s, e)
+                    langdef = self.parent().editor.tm.get_langdef_from_string(l)
+                    self.parent().editor.tm.surround_with_languagebox(langdef)
                 self.parent().editor.tm.reparse(s)
                 self.parent().editor.getWindow().btReparse([]) # refresh gui
                 self.parent().editor.update() # refresh code editor

--- a/lib/eco/editortab.py
+++ b/lib/eco/editortab.py
@@ -115,7 +115,7 @@ class EditorTab(QWidget):
         elif isinstance(lang, EcoFile):
             incparser, inclexer = lang.load()
             self.editor.set_mainlanguage(incparser, inclexer, lang.name)
-            incparser.setup_autolbox(lang.name)
+            incparser.setup_autolbox(lang.name, inclexer)
 
     def toggle_breakpoint(self, isTemp, number, from_click):
         self.emit(SIGNAL("breakpoint"), isTemp, number, from_click)

--- a/lib/eco/gui/gui.ui
+++ b/lib/eco/gui/gui.ui
@@ -46,7 +46,7 @@
      <x>0</x>
      <y>0</y>
      <width>1069</width>
-     <height>17</height>
+     <height>26</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -59,7 +59,8 @@
      </property>
      <property name="icon">
       <iconset theme="document-open-recent">
-       <normaloff>.</normaloff>.</iconset>
+       <normaloff/>
+      </iconset>
      </property>
      <addaction name="actionActionDummy"/>
     </widget>
@@ -118,7 +119,8 @@
      </property>
      <property name="icon">
       <iconset theme="reload">
-       <normaloff>.</normaloff>.</iconset>
+       <normaloff/>
+      </iconset>
      </property>
      <addaction name="actionDummy"/>
     </widget>
@@ -135,6 +137,7 @@
     <addaction name="actionFind_next"/>
     <addaction name="separator"/>
     <addaction name="actionAdd_language_box"/>
+    <addaction name="actionRemove_language_box"/>
     <addaction name="actionSelect_next_language_box"/>
     <addaction name="menuChange_language_box"/>
     <addaction name="separator"/>
@@ -194,6 +197,7 @@
    <addaction name="actionPaste"/>
    <addaction name="separator"/>
    <addaction name="actionAdd_language_box"/>
+   <addaction name="actionRemove_language_box"/>
    <addaction name="actionSelect_next_language_box"/>
    <addaction name="separator"/>
    <addaction name="actionCode_complete"/>
@@ -461,7 +465,8 @@
    </property>
    <property name="icon">
     <iconset theme="edit-undo">
-     <normaloff>.</normaloff>.</iconset>
+     <normaloff/>
+    </iconset>
    </property>
    <property name="text">
     <string>Undo</string>
@@ -476,7 +481,8 @@
    </property>
    <property name="icon">
     <iconset theme="edit-redo">
-     <normaloff>.</normaloff>.</iconset>
+     <normaloff/>
+    </iconset>
    </property>
    <property name="text">
     <string>Redo</string>
@@ -491,7 +497,8 @@
    </property>
    <property name="icon">
     <iconset theme="edit-cut">
-     <normaloff>.</normaloff>.</iconset>
+     <normaloff/>
+    </iconset>
    </property>
    <property name="text">
     <string>Cut</string>
@@ -506,7 +513,8 @@
    </property>
    <property name="icon">
     <iconset theme="edit-copy">
-     <normaloff>.</normaloff>.</iconset>
+     <normaloff/>
+    </iconset>
    </property>
    <property name="text">
     <string>Copy</string>
@@ -521,7 +529,8 @@
    </property>
    <property name="icon">
     <iconset theme="edit-paste">
-     <normaloff>.</normaloff>.</iconset>
+     <normaloff/>
+    </iconset>
    </property>
    <property name="text">
     <string>Paste</string>
@@ -551,7 +560,8 @@
    </property>
    <property name="icon">
     <iconset theme="list-add">
-     <normaloff>.</normaloff>.</iconset>
+     <normaloff/>
+    </iconset>
    </property>
    <property name="text">
     <string>Add language box</string>
@@ -566,7 +576,8 @@
    </property>
    <property name="icon">
     <iconset theme="go-next">
-     <normaloff>.</normaloff>.</iconset>
+     <normaloff/>
+    </iconset>
    </property>
    <property name="text">
     <string>Select next language box</string>
@@ -638,7 +649,8 @@
    </property>
    <property name="icon">
     <iconset theme="edit-select-all">
-     <normaloff>.</normaloff>.</iconset>
+     <normaloff/>
+    </iconset>
    </property>
    <property name="text">
     <string>Select all</string>
@@ -653,7 +665,8 @@
    </property>
    <property name="icon">
     <iconset theme="document-export">
-     <normaloff>.</normaloff>.</iconset>
+     <normaloff/>
+    </iconset>
    </property>
    <property name="text">
     <string>Export as...</string>
@@ -668,7 +681,8 @@
    </property>
    <property name="icon">
     <iconset theme="document-export">
-     <normaloff>.</normaloff>.</iconset>
+     <normaloff/>
+    </iconset>
    </property>
    <property name="text">
     <string>Export</string>
@@ -680,7 +694,8 @@
   <action name="actionSettings">
    <property name="icon">
     <iconset theme="gnome-settings">
-     <normaloff>.</normaloff>.</iconset>
+     <normaloff/>
+    </iconset>
    </property>
    <property name="text">
     <string>Settings...</string>
@@ -775,7 +790,8 @@
    </property>
    <property name="icon">
     <iconset theme="media-playback-start">
-     <normaloff>.</normaloff>.</iconset>
+     <normaloff/>
+    </iconset>
    </property>
    <property name="text">
     <string>Continue</string>
@@ -790,7 +806,8 @@
    </property>
    <property name="icon">
     <iconset theme="down">
-     <normaloff>.</normaloff>.</iconset>
+     <normaloff/>
+    </iconset>
    </property>
    <property name="text">
     <string>Step Into</string>
@@ -805,7 +822,8 @@
    </property>
    <property name="icon">
     <iconset theme="go-jump">
-     <normaloff>.</normaloff>.</iconset>
+     <normaloff/>
+    </iconset>
    </property>
    <property name="text">
     <string>Step Over</string>
@@ -820,7 +838,8 @@
    </property>
    <property name="icon">
     <iconset theme="player_stop">
-     <normaloff>.</normaloff>.</iconset>
+     <normaloff/>
+    </iconset>
    </property>
    <property name="text">
     <string>Stop</string>
@@ -875,6 +894,19 @@
    </property>
    <property name="text">
     <string>Insert</string>
+   </property>
+  </action>
+  <action name="actionRemove_language_box">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="icon">
+    <iconset theme="list-remove">
+     <normaloff/>
+    </iconset>
+   </property>
+   <property name="text">
+    <string>Remove language box</string>
    </property>
   </action>
  </widget>

--- a/lib/eco/incparser/incparser.py
+++ b/lib/eco/incparser/incparser.py
@@ -132,8 +132,8 @@ class IncParser(object):
 
         self.whitespaces = whitespaces
 
-    def setup_autolbox(self, lang):
-        self.autodetector = NewAutoLboxDetector(self)
+    def setup_autolbox(self, lang, origlexer):
+        self.autodetector = NewAutoLboxDetector(self, origlexer)
         self.autodetector.preload(lang)
 
     def init_ast(self, magic_parent=None):
@@ -354,8 +354,11 @@ class IncParser(object):
                 logging.debug("After breakdown: %s", self.stack[-1])
                 self.validating = False
             else:
-                if self.autodetector and self.option_autolbox_find and self.autodetector.detect_lbox(la):
-                    pass # we can immediately apply the language box here in the future
+                if self.autodetector and self.option_autolbox_find:
+                    if type(la.symbol) is MagicTerminal and la.tbd:
+                        self.autodetector.check_remove_lbox(la)
+                    else:
+                        self.autodetector.detect_lbox(la)
                 self.error_nodes.append(la)
                 if self.rm.recover(la):
                     # recovered, continue parsing

--- a/lib/eco/test/javalua_expr.json
+++ b/lib/eco/test/javalua_expr.json
@@ -1,0 +1,17 @@
+{
+    "name": "Java + Lua expr",
+    "file": "grammars/java15.eco",
+    "base": "",
+    "visibility": ["newfile"],
+    "limit_historic_tokens": false,
+    "compositions": [
+        {
+            "location": "unary_expression",
+            "name": "Lua expr",
+            "file": "grammars/lua5_3.eco",
+            "base": "Lua",
+            "subset": "explist",
+            "visibility": ["submenu"]
+        }
+    ]
+}

--- a/lib/eco/test/javaphp_expr.json
+++ b/lib/eco/test/javaphp_expr.json
@@ -1,0 +1,17 @@
+{
+    "name": "Java + PHP expr",
+    "file": "grammars/java15.eco",
+    "base": "",
+    "visibility": ["newfile"],
+    "limit_historic_tokens": false,
+    "compositions": [
+        {
+            "location": "unary_expression",
+            "name": "PHP expre",
+            "file": "grammars/php.eco",
+            "base": "Php",
+            "subset": "expr_without_variable",
+            "visibility": ["submenu"]
+        }
+    ]
+}

--- a/lib/eco/test/luasqlite_expr.json
+++ b/lib/eco/test/luasqlite_expr.json
@@ -1,0 +1,17 @@
+{
+    "name": "Lua + Sqlite",
+    "file": "grammars/lua5_3.eco",
+    "base": "",
+    "visibility": ["newfile"],
+    "limit_historic_tokens": false,
+    "compositions": [
+        {
+            "location": "explist",
+            "name": "SQL expr (Lua+Sqlite)",
+            "file": "grammars/sqlite.eco",
+            "base": "Sql",
+            "subset": null,
+            "visibility": ["submenu"]
+        }
+    ]
+}

--- a/lib/eco/test/sqlitejava_expr.json
+++ b/lib/eco/test/sqlitejava_expr.json
@@ -1,0 +1,17 @@
+{
+    "name": "Sqlite + Java",
+    "file": "grammars/sqlite.eco",
+    "base": "",
+    "visibility": ["newfile"],
+    "limit_historic_tokens": false,
+    "compositions": [
+        {
+            "location": "expr",
+            "name": "Java expr",
+            "file": "grammars/java15.eco",
+            "base": "Java",
+            "subset": "assignment_expression",
+            "visibility": ["submenu"]
+        }
+    ]
+}

--- a/lib/eco/test/test_eco.py
+++ b/lib/eco/test/test_eco.py
@@ -5315,3 +5315,28 @@ y = 2"""
 
         assert len(treemanager.parsers) == 2
         assert parser.last_status == True
+
+    @pytest.mark.skipif("TRAVIS" in os.environ and os.environ["TRAVIS"] == "true", reason="Sqlite takes too long to built on Travis. Skip!")
+    def test_sqlite_java_shrink(self):
+        grm = load_json_grammar("test/sqlitejava_expr.json")
+        parser, lexer = grm.load()
+        parser.setup_autolbox(grm.name, lexer)
+        treemanager = TreeManager()
+        treemanager.option_autolbox_insert = True
+        treemanager.add_parser(parser, lexer, "")
+        p = "SELECT a FROM t;"
+        for c in p:
+            treemanager.key_normal(c)
+        assert len(treemanager.parsers) == 1
+        assert parser.last_status == True
+
+        treemanager.key_home()
+        for i in range(8):
+            treemanager.key_cursors(RIGHT)
+        treemanager.key_normal("(")
+        treemanager.key_normal(")")
+        treemanager.key_normal(".") # wrap `a(). FROM` in lbox
+        treemanager.key_normal("d") # shrink box to `a().d`
+
+        assert len(treemanager.parsers) == 2
+        assert parser.last_status == True

--- a/lib/eco/test/test_eco.py
+++ b/lib/eco/test/test_eco.py
@@ -5340,3 +5340,30 @@ y = 2"""
 
         assert len(treemanager.parsers) == 2
         assert parser.last_status == True
+
+    @pytest.mark.skipif("TRAVIS" in os.environ and os.environ["TRAVIS"] == "true", reason="Sqlite takes too long to built on Travis. Skip!")
+    def test_lua_sqlite_bug(self):
+        grm = load_json_grammar("test/luasqlite_expr.json")
+        parser, lexer = grm.load()
+        parser.setup_autolbox(grm.name, lexer)
+        treemanager = TreeManager()
+        treemanager.option_autolbox_insert = True
+        treemanager.add_parser(parser, lexer, "")
+        p = """x = 1,2
+y = 2"""
+        for c in p:
+            treemanager.key_normal(c)
+        assert len(treemanager.parsers) == 1
+        assert parser.last_status == True
+
+        treemanager.key_cursors(UP)
+        treemanager.key_end()
+        treemanager.key_cursors(LEFT)
+        treemanager.key_cursors(LEFT)
+        treemanager.key_backspace()
+        p2 = "SELECT a FROM t1;"
+        for c in p2:
+            treemanager.key_normal(c)
+
+        assert len(treemanager.parsers) == 2
+        assert parser.last_status == True

--- a/lib/eco/test/test_eco.py
+++ b/lib/eco/test/test_eco.py
@@ -1405,7 +1405,7 @@ class Test_Languageboxes(Test_Python):
 
     def test_java_python_dont_lex_lboxes(self):
         parser, lexer = javapy.load()
-        parser.setup_autolbox(javapy.name)
+        parser.setup_autolbox(javapy.name, lexer)
         treemanager = TreeManager()
         treemanager.add_parser(parser, lexer, "")
         p = """class X {
@@ -4602,7 +4602,7 @@ class Test_AutoLanguageBoxDetection():
 
     def test_pythonsql(self):
         parser, lexer = pythonsql.load()
-        parser.setup_autolbox(pythonsql.name)
+        parser.setup_autolbox(pythonsql.name, lexer)
         treemanager = TreeManager()
         treemanager.option_autolbox_insert = True
         treemanager.add_parser(parser, lexer, "")
@@ -4615,7 +4615,7 @@ class Test_AutoLanguageBoxDetection():
 
     def test_pythonsql2(self):
         parser, lexer = pythonsql.load()
-        parser.setup_autolbox(pythonsql.name)
+        parser.setup_autolbox(pythonsql.name, lexer)
         treemanager = TreeManager()
         treemanager.option_autolbox_insert = True
         treemanager.add_parser(parser, lexer, "")
@@ -4630,7 +4630,7 @@ class Test_AutoLanguageBoxDetection():
 
     def test_java_python(self):
         parser, lexer = javapy.load()
-        parser.setup_autolbox(javapy.name)
+        parser.setup_autolbox(javapy.name, lexer)
         treemanager = TreeManager()
         treemanager.option_autolbox_insert = True
         treemanager.add_parser(parser, lexer, "")
@@ -4651,7 +4651,7 @@ class Test_AutoLanguageBoxDetection():
 
     def test_java_python2(self):
         parser, lexer = javapy.load()
-        parser.setup_autolbox(javapy.name)
+        parser.setup_autolbox(javapy.name, lexer)
         treemanager = TreeManager()
         treemanager.option_autolbox_insert = True
         treemanager.add_parser(parser, lexer, "")
@@ -4676,7 +4676,7 @@ class Test_AutoLanguageBoxDetection():
         """Currently fails as `public` is being parsed into the Python language
         box."""
         parser, lexer = javapy.load()
-        parser.setup_autolbox(javapy.name)
+        parser.setup_autolbox(javapy.name, lexer)
         treemanager = TreeManager()
         treemanager.option_autolbox_insert = True
         treemanager.add_parser(parser, lexer, "")
@@ -4708,7 +4708,7 @@ class Test_AutoLanguageBoxDetection():
 
     def test_php_python5_first_line_box(self):
         parser, lexer = phppython.load()
-        parser.setup_autolbox(phppython.name)
+        parser.setup_autolbox(phppython.name, lexer)
         treemanager = TreeManager()
         treemanager.option_autolbox_insert = True
         treemanager.add_parser(parser, lexer, "")
@@ -4724,7 +4724,7 @@ class Test_AutoLanguageBoxDetection():
         """Results in two options for language box:
         Python or Python expression"""
         parser, lexer = phppython.load()
-        parser.setup_autolbox(phppython.name)
+        parser.setup_autolbox(phppython.name, lexer)
         treemanager = TreeManager()
         treemanager.option_autolbox_insert = True
         treemanager.add_parser(parser, lexer, "")
@@ -4745,7 +4745,7 @@ class Test_AutoLanguageBoxDetection():
         expression `1 or not 2`. Instead they only contain `not 2` because of
         the way PHP parses `or`."""
         parser, lexer = phppython.load()
-        parser.setup_autolbox(phppython.name)
+        parser.setup_autolbox(phppython.name, lexer)
         treemanager = TreeManager()
         treemanager.option_autolbox_insert = True
         treemanager.add_parser(parser, lexer, "")
@@ -4770,7 +4770,7 @@ class Test_AutoLanguageBoxDetection():
         lang_dict[grm.name] = grm
 
         parser, lexer = grm.load()
-        parser.setup_autolbox(grm.name)
+        parser.setup_autolbox(grm.name, lexer)
         treemanager = TreeManager()
         treemanager.option_autolbox_insert = True
         treemanager.add_parser(parser, lexer, "")
@@ -4795,7 +4795,7 @@ class Test_AutoLanguageBoxDetection():
         lang_dict[grm.name] = grm
 
         parser, lexer = grm.load()
-        parser.setup_autolbox(grm.name)
+        parser.setup_autolbox(grm.name, lexer)
         treemanager = TreeManager()
         treemanager.option_autolbox_insert = True
         treemanager.add_parser(parser, lexer, "")
@@ -4816,7 +4816,7 @@ class Test_AutoLanguageBoxDetection():
 
     def test_autoremove_pythonsql(self):
         parser, lexer = pythonsql.load()
-        parser.setup_autolbox(pythonsql.name)
+        parser.setup_autolbox(pythonsql.name, lexer)
         treemanager = TreeManager()
         treemanager.option_autolbox_insert = True
         treemanager.add_parser(parser, lexer, "")
@@ -4839,7 +4839,7 @@ class Test_AutoLanguageBoxDetection():
 
     def test_php_python_paste(self):
         parser, lexer = phppython.load()
-        parser.setup_autolbox(phppython.name)
+        parser.setup_autolbox(phppython.name, lexer)
         treemanager = TreeManager()
         treemanager.option_autolbox_insert = True
         treemanager.add_parser(parser, lexer, "")
@@ -4862,7 +4862,7 @@ class Test_AutoLanguageBoxDetection():
 
     def test_php_python_paste2(self):
         parser, lexer = phppython.load()
-        parser.setup_autolbox(phppython.name)
+        parser.setup_autolbox(phppython.name, lexer)
         treemanager = TreeManager()
         treemanager.option_autolbox_insert = True
         treemanager.add_parser(parser, lexer, "")
@@ -4887,7 +4887,7 @@ class Test_AutoLanguageBoxDetection():
 
     def test_python_sql_bug(self):
         parser, lexer = pythonsql.load()
-        parser.setup_autolbox(pythonsql.name)
+        parser.setup_autolbox(pythonsql.name, lexer)
         treemanager = TreeManager()
         treemanager.option_autolbox_insert = True
         treemanager.add_parser(parser, lexer, "")
@@ -4909,7 +4909,7 @@ class Test_AutoLanguageBoxDetection():
 
     def test_newbug(self):
         parser, lexer = phppython.load()
-        parser.setup_autolbox(phppython.name)
+        parser.setup_autolbox(phppython.name, lexer)
         treemanager = TreeManager()
         treemanager.option_autolbox_insert = True
         treemanager.add_parser(parser, lexer, "")
@@ -4936,7 +4936,7 @@ class Test_AutoLanguageBoxDetection():
 
     def test_newbug2(self):
         parser, lexer = phppython.load()
-        parser.setup_autolbox(phppython.name)
+        parser.setup_autolbox(phppython.name, lexer)
         treemanager = TreeManager()
         treemanager.option_autolbox_insert = True
         treemanager.add_parser(parser, lexer, "")
@@ -4947,7 +4947,7 @@ class Test_AutoLanguageBoxDetection():
 
     def test_newbug3(self):
         parser, lexer = phppython.load()
-        parser.setup_autolbox(phppython.name)
+        parser.setup_autolbox(phppython.name, lexer)
         treemanager = TreeManager()
         treemanager.option_autolbox_insert = True
         treemanager.add_parser(parser, lexer, "")
@@ -4963,7 +4963,7 @@ class Test_AutoLanguageBoxDetection():
 
     def test_php_bug4(self):
         parser, lexer = phppython.load()
-        parser.setup_autolbox(phppython.name)
+        parser.setup_autolbox(phppython.name, lexer)
         treemanager = TreeManager()
         treemanager.option_autolbox_insert = True
         treemanager.add_parser(parser, lexer, "")
@@ -4980,7 +4980,7 @@ class Test_AutoLanguageBoxDetection():
 
     def test_java_py_string(self):
         parser, lexer = javapy.load()
-        parser.setup_autolbox(javapy.name)
+        parser.setup_autolbox(javapy.name, lexer)
         treemanager = TreeManager()
         treemanager.option_autolbox_insert = True
         treemanager.add_parser(parser, lexer, "")
@@ -4992,7 +4992,7 @@ class Test_AutoLanguageBoxDetection():
 
     def test_java_sql_autoremove_valid_boxes(self):
         parser, lexer = javasqlchemical.load()
-        parser.setup_autolbox(javasqlchemical.name)
+        parser.setup_autolbox(javasqlchemical.name, lexer)
         treemanager = TreeManager()
         treemanager.option_autolbox_insert = True
         treemanager.add_parser(parser, lexer, "")
@@ -5022,7 +5022,7 @@ class Test_AutoLanguageBoxDetection():
 
     def test_java_python_method_insert_bug1(self):
         parser, lexer = javapy.load()
-        parser.setup_autolbox(javapy.name)
+        parser.setup_autolbox(javapy.name, lexer)
         treemanager = TreeManager()
         treemanager.option_autolbox_insert = True
         treemanager.add_parser(parser, lexer, "")
@@ -5050,7 +5050,7 @@ class Test_AutoLanguageBoxDetection():
         """Once an automatically inserted language box has been
         undone, it shouldn't be inserted again on another change."""
         parser, lexer = javapy.load()
-        parser.setup_autolbox(javapy.name)
+        parser.setup_autolbox(javapy.name, lexer)
         treemanager = TreeManager()
         treemanager.option_autolbox_insert = True
         treemanager.add_parser(parser, lexer, "")
@@ -5083,7 +5083,7 @@ class Test_AutoLanguageBoxDetection():
 
     def test_php_python_whitespace_bug(self):
         parser, lexer = phppython.load()
-        parser.setup_autolbox(phppython.name)
+        parser.setup_autolbox(phppython.name, lexer)
         treemanager = TreeManager()
         treemanager.option_autolbox_insert = True
         treemanager.add_parser(parser, lexer, "")
@@ -5129,7 +5129,7 @@ class Test_AutoLanguageBoxDetection():
 }"""
 
         parser, lexer = javasql.load()
-        parser.setup_autolbox(javasql.name)
+        parser.setup_autolbox(javasql.name, lexer)
         treemanager = TreeManager()
         treemanager.option_autolbox_insert = True
         treemanager.add_parser(parser, lexer, "")
@@ -5167,7 +5167,7 @@ WHERE ProductID IN (SELECT ProductID FROM OrderDetails WHERE Quantity = 10);"""
         should always prioritise the outer language instead even if the language
         box is a valid insertion."""
         parser, lexer = phppython.load()
-        parser.setup_autolbox(phppython.name)
+        parser.setup_autolbox(phppython.name, lexer)
         treemanager = TreeManager()
         treemanager.option_autolbox_insert = True
         treemanager.add_parser(parser, lexer, "")
@@ -5191,7 +5191,7 @@ WHERE ProductID IN (SELECT ProductID FROM OrderDetails WHERE Quantity = 10);"""
         optional in PHP and thus can be used in a Python box without making the
         PHP program invalid."""
         parser, lexer = phppython.load()
-        parser.setup_autolbox(phppython.name)
+        parser.setup_autolbox(phppython.name, lexer)
         treemanager = TreeManager()
         treemanager.option_autolbox_insert = True
         treemanager.add_parser(parser, lexer, "")
@@ -5212,4 +5212,28 @@ WHERE ProductID IN (SELECT ProductID FROM OrderDetails WHERE Quantity = 10);"""
         treemanager.key_normal("d")
 
         assert len(treemanager.parsers) == 1
+        assert parser.last_status == False
+
+    def test_java_lua_dont_remove_explicit_lboxes(self):
+        grm = load_json_grammar("test/javalua_expr.json")
+        parser, lexer = grm.load()
+        parser.setup_autolbox(grm.name, lexer)
+        treemanager = TreeManager()
+        treemanager.option_autolbox_insert = True
+        treemanager.add_parser(parser, lexer, "")
+        p = """class X {
+    int x = 1;
+}"""
+        for c in p:
+            treemanager.key_normal(c)
+        assert len(treemanager.parsers) == 1
+        assert parser.last_status == True
+
+        treemanager.key_cursors(UP)
+        treemanager.key_end()
+        treemanager.key_cursors(LEFT)
+        treemanager.add_languagebox(lang_dict["Lua expr"])
+        treemanager.key_normal("a")
+
+        assert len(treemanager.parsers) == 2
         assert parser.last_status == False

--- a/lib/eco/treemanager.py
+++ b/lib/eco/treemanager.py
@@ -1068,14 +1068,18 @@ class TreeManager(object):
     def key_home(self, shift=False):
         self.log_input("key_home", str(shift))
         self.unselect()
+        lbox = self.get_languagebox(self.cursor.node)
         self.cursor.home()
+        self.update_tbd(lbox)
         if shift:
             self.selection_end = self.cursor.copy()
 
     def key_end(self, shift=False):
         self.log_input("key_end", str(shift))
         self.unselect()
+        lbox = self.get_languagebox(self.cursor.node)
         self.cursor.end()
+        self.update_tbd(lbox)
         if shift:
             self.selection_end = self.cursor.copy()
 
@@ -1257,6 +1261,8 @@ class TreeManager(object):
         # with shift, no   selection -> start new selection, modify selection
         # with shift, with selection -> modify selection
 
+        lbox = self.get_languagebox(self.cursor.node)
+
         if shift:
             if not self.hasSelection():
                 self.selection_start = self.cursor.copy()
@@ -1268,6 +1274,8 @@ class TreeManager(object):
             else:
                 self.cursor_movement(key)
             self.unselect()
+
+        self.update_tbd(lbox)
 
     def jump_cursor_within_selection(self, key):
         """
@@ -1501,6 +1509,13 @@ class TreeManager(object):
             self.delete_parser(root)
             return True
         return False
+
+    def update_tbd(self, lbox):
+        if lbox is None:
+            return
+        newlbox = self.get_languagebox(self.cursor.node)
+        if lbox is not newlbox:
+            lbox.tbd = False
 
     def create_node(self, text, lbox=False):
         if lbox:

--- a/lib/eco/treemanager.py
+++ b/lib/eco/treemanager.py
@@ -1430,7 +1430,7 @@ class TreeManager(object):
         self.edit_rightnode = False
         # cut text
         text = self.copySelection()
-        self.deleteSelection()
+        self.deleteSelection(reparse=False)
         lbox = self.add_languagebox(language)
         self.pasteText(text)
         lbox.tbd = auto
@@ -1730,7 +1730,7 @@ class TreeManager(object):
             self.changed = True
             return text
 
-    def deleteSelection(self):
+    def deleteSelection(self, reparse=True):
         #XXX simple version: later we might want to modify the nodes directly
         self.tool_data_is_dirty = True
         nodes, diff_start, diff_end = self.get_nodes_from_selection()
@@ -1787,7 +1787,8 @@ class TreeManager(object):
         repairnode = nodes[-1]
         if repairnode.deleted:
             repairnode = self.cursor.find_previous_visible(repairnode, cross_lang=True)
-        self.reparse(repairnode)
+        if reparse:
+            self.reparse(repairnode)
 
     def delete_if_empty(self, node):
         if node.symbol.name == "":

--- a/lib/eco/treemanager.py
+++ b/lib/eco/treemanager.py
@@ -1413,7 +1413,7 @@ class TreeManager(object):
 
         # Create parser, priorities and lexer
         incparser, inclexer = self.get_parser_lexer_for_language(language, True)
-        incparser.setup_autolbox(language.name)
+        incparser.setup_autolbox(language.name, inclexer)
         root = incparser.previous_version.parent
         root.magic_backpointer = lbox
         self.add_parser(incparser, inclexer, language.name)
@@ -2124,7 +2124,7 @@ class TreeManager(object):
             p = temp[0]
             lbox = p.previous_version.parent.get_magicterminal()
             if lbox and lbox.tbd:
-                if self.lbox_autoremove_test(lbox, p.last_status):
+                if lbox.tbd == "remove" or self.lbox_autoremove_test(lbox, p.last_status):
                     self.remove_languagebox(lbox)
                 else:
                     # try to expand language boxes

--- a/lib/eco/treemanager.py
+++ b/lib/eco/treemanager.py
@@ -1439,6 +1439,13 @@ class TreeManager(object):
         self.input_log.pop()
         return
 
+    def remove_selected_lbox(self):
+        root = self.cursor.node.get_root()
+        if hasattr(root, "magic_backpointer"):
+            lbox = root.magic_backpointer
+            if lbox:
+                self.remove_languagebox(lbox)
+
     def remove_languagebox(self, lbox):
         if lbox.deleted:
             # Language box was already removed by an earlier error
@@ -1447,6 +1454,7 @@ class TreeManager(object):
         root = lbox.symbol.ast
         bos = root.children[0]
         eos = root.children[-1]
+        left = lbox.prev_term
 
         # move all nodes from lbox to the outside
         node = bos.next_term
@@ -1467,6 +1475,8 @@ class TreeManager(object):
         for t in top:
             #XXX add method to relex a range, e.g. relex(start, end)
             self.relex(t)
+        self.relex(left)
+        self.cursor.restore_last_x()
         # reparse
         self.reparse(top[0], skipautolbox = True)
 

--- a/lib/eco/treemanager.py
+++ b/lib/eco/treemanager.py
@@ -455,6 +455,8 @@ class TreeManager(object):
         self.option_autolbox_find = True
         self.option_autolbox_insert = False
 
+        self.skipautolbox = False
+
         # This code and the can_profile() method should probably be refactored.
         self.langs_with_profiler = {
             "Python + Prolog" : False,
@@ -2140,7 +2142,7 @@ class TreeManager(object):
         TreeManager.version = self.version
 
         # Now check for auto language boxes
-        if skipautolbox or self.option_autolbox_insert is False:
+        if self.skipautolbox or skipautolbox or self.option_autolbox_insert is False:
             return
 
         parsers = list(self.parsers) # copy to avoid processing newly added parsers
@@ -2164,11 +2166,12 @@ class TreeManager(object):
                     ctemp = self.cursor.get_x()
                     ltemp = self.cursor.line
                     self.select_from_to(s, e)
+                    self.skipautolbox = True # block automatic lboxes during automatic insertion
                     self.surround_with_languagebox(lang_dict[l], True)
                     self.cursor.line = ltemp
                     self.cursor.move_to_x(ctemp)
-                    self.reparse(s.prev_term, skipautolbox=True)
                     self.undo_snapshot()
+                    self.skipautolbox = False
 
     def lbox_expand_test(self, lbox):
         """Checks if the language box can be expanded by moving following


### PR DESCRIPTION
**Requires merging #243 first.**

This PR adds various improvements and additions to automatic language boxes:
- e5653c8: Allows language boxes to expand if tokens following the box can be moved inside the box. This commit also improves loose/fixed boxes by fixating automatically inserted (loose) language boxes when the user manually moves the cursor out of them.
- e4f5bc3: Extends e5653c8. If there are multiple expansion possibilities, they are shown via the lightbulb icon on the left.
- 4df519f: Added long overdue option to remove language boxes and interpret their content in the outer language.
- 8f39a27: Use error recovery during the automatic removal check.
- 78c5943: Allows language boxes to shrink again if they contain a parse error.
- 830798d: Fixes e5653c8 to only fixate language boxes if they were manually chosen by the user.
- 17a426b: Fix: Makes sure that automatically inserted language boxes are reparsed in a single step (previously we would reparse after deletion of the old nodes and then again after inserting the language box).
- 437fd5f: Improves e5653c8. Only expand language boxes if this doesn't introducing errors immediately after the box.