### PR TITLE
Allow users to manually lock/unlock language boxes

### DIFF
--- a/lib/eco/eco.py
+++ b/lib/eco/eco.py
@@ -644,6 +644,7 @@ class Window(QtGui.QMainWindow):
         self.connect(self.ui.actionShow_lspaceview, SIGNAL("triggered()"), self.view_in_lspace)
         self.connect(self.ui.menuChange_language_box, SIGNAL("aboutToShow()"), self.showEditMenu)
         self.connect(self.ui.actionRemove_language_box, SIGNAL("triggered()"), self.remove_languagebox)
+        self.connect(self.ui.actionLock_Unlock_language_box, SIGNAL("triggered()"), self.toggle_lock_languagebox)
         self.connect(self.ui.menuRecent_files, SIGNAL("aboutToShow()"), self.showRecentFiles)
         self.connect(self.ui.actionInput_log, SIGNAL("triggered()"), self.show_input_log)
 
@@ -798,10 +799,19 @@ class Window(QtGui.QMainWindow):
         newmenu = QMenu("Add languagebox", self)
         newmenu.setIcon(QtGui.QIcon.fromTheme("list-add"))
         self.getEditor().createSubgrammarMenu(newmenu)
-
-        menu.addMenu(changemenu)
         menu.addMenu(newmenu)
-        menu.addAction(self.ui.actionRemove_language_box)
+
+        lbox = self.getEditor().tm.get_selected_languagebox()
+        if lbox is not None:
+            menu.addAction(self.ui.actionRemove_language_box)
+            lockaction = QAction(QIcon.fromTheme("lock"), "Lock language box", menu)
+            self.connect(lockaction, SIGNAL("triggered()"), self.toggle_lock_languagebox)
+            menu.addAction(lockaction)
+            if not lbox.tbd:
+                lockaction.setText("Unlock language box")
+
+            menu.addMenu(changemenu)
+
         menu.addAction(self.ui.actionSelect_next_language_box)
         menu.addSeparator()
         menu.addAction(self.ui.actionCode_complete)
@@ -1019,6 +1029,9 @@ class Window(QtGui.QMainWindow):
         self.getEditor().tm.remove_selected_lbox()
         self.btReparse([])
         self.getEditor().update()
+
+    def toggle_lock_languagebox(self):
+        self.getEditor().tm.toggle_lock_languagebox()
 
     def show_code_completion(self):
         self.getEditor().showCodeCompletion()
@@ -1468,6 +1481,7 @@ class Window(QtGui.QMainWindow):
         self.ui.actionFind_next.setEnabled(enabled)
         self.ui.actionAdd_language_box.setEnabled(enabled)
         self.ui.actionRemove_language_box.setEnabled(enabled)
+        self.ui.actionLock_Unlock_language_box.setEnabled(enabled)
         self.ui.actionSelect_next_language_box.setEnabled(enabled)
         self.ui.actionAutolboxInsert.setEnabled(enabled)
         self.ui.actionAutolboxFind.setEnabled(enabled)

--- a/lib/eco/gui/gui.ui
+++ b/lib/eco/gui/gui.ui
@@ -140,6 +140,7 @@
     <addaction name="actionRemove_language_box"/>
     <addaction name="actionSelect_next_language_box"/>
     <addaction name="menuChange_language_box"/>
+    <addaction name="actionLock_Unlock_language_box"/>
     <addaction name="separator"/>
     <addaction name="actionCode_complete"/>
    </widget>
@@ -907,6 +908,22 @@
    </property>
    <property name="text">
     <string>Remove language box</string>
+   </property>
+  </action>
+  <action name="actionLock_Unlock_language_box">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="icon">
+    <iconset theme="lock">
+     <normaloff/>
+    </iconset>
+   </property>
+   <property name="text">
+    <string>Lock/Unlock language box</string>
+   </property>
+   <property name="toolTip">
+    <string>Lock/Unlock language box</string>
    </property>
   </action>
  </widget>

--- a/lib/eco/treemanager.py
+++ b/lib/eco/treemanager.py
@@ -570,6 +570,9 @@ class TreeManager(object):
                 print("Namebinding file '%s' not found." % (lang.nb_file))
 
 
+    def get_selected_languagebox(self):
+        return self.get_languagebox(self.cursor.node)
+
     def get_languagebox(self, node):
         root = node.get_root()
         lbox = root.get_magicterminal()
@@ -1481,6 +1484,13 @@ class TreeManager(object):
         self.cursor.restore_last_x()
         # reparse
         self.reparse(top[0], skipautolbox = True)
+
+    def toggle_lock_languagebox(self):
+        root = self.cursor.node.get_root()
+        if hasattr(root, "magic_backpointer"):
+            lbox = root.magic_backpointer
+            if lbox:
+                lbox.tbd = not lbox.tbd
 
     def change_languagebox(self, language):
         self.log_input("change_languagebox", repr(language.name))


### PR DESCRIPTION
Whenever the user leaves a language box it gets automatically locked,
which means it will not be automatically removed/shrunken/expanded anymore.
This adds an entry to the context menu that allows users to manually
lock/unlock language boxes again.