### PR TITLE
Optimise lexer runtime and memory usage

### DIFF
--- a/lib/eco/treelexer/lexer.py
+++ b/lib/eco/treelexer/lexer.py
@@ -298,12 +298,14 @@ class TreePatternMatcher(PatternMatcher):
         self.pos = state[0]
         self.text = state[1]
         self.exactmatch = state[2]
-        self.result = state[3]
-        self.read_nodes = state[4]
+        assert state[3] <= len(self.result)
+        del self.result[state[3]:]
+        assert state[4] <= len(self.read_nodes)
+        del self.read_nodes[state[4]:]
         self.la = state[5]
 
     def save_state(self):
-        return (self.pos, self.text, self.exactmatch, list(self.result), list(self.read_nodes), self.la)
+        return (self.pos, self.text, self.exactmatch, len(self.result), len(self.read_nodes), self.la)
 
     def match_one(self, pattern):
         if type(self.text.symbol) in [MagicTerminal, IndentationTerminal]:


### PR DESCRIPTION
For regexs like OR, greedy-*, etc. we need backtracking, which requires
storing previous lexing states. Previously, we naively just cloned and
stored the entire lexing state, which included the string we have matched
so far as a list of characters. This list can grow very large and since
every further character we match with greedy-* needs to store the lastest
state, this would lead to us cloning this list multiple times over.
Luckily, we only ever backtrack to a smaller state, which means we only
need to store the index of the last state. Backtracking to this state can
then simply be done by deleting all elements after that index.

Note that the treelexer also stores all nodes we have read so far, so we
can apply the same optimisation there as well.

This optimisation reduced a worst-case scenario by 53x (from 16s to 0.3s).