### PR TITLE
Allow automatic language boxes to split up tokens

### DIFF
--- a/lib/eco/autolboxdetector.py
+++ b/lib/eco/autolboxdetector.py
@@ -78,14 +78,14 @@ class NewAutoLboxDetector(object):
 
         maxdistance = {}
         # find max distance by startnode
-        for start, _, _, dist in valid:
+        for start, _, _, dist, _ in valid:
             if not start in maxdistance or maxdistance[start] < dist:
                 maxdistance[start] = dist
         # remove all startnodes which have less than max distance
         validnew = set()
-        for start, end, lang, dist in valid:
+        for start, end, lang, dist, split in valid:
             if dist >= maxdistance[start]:
-                validnew.add((start, end, lang))
+                validnew.add((start, end, lang, split))
 
         valid = list(validnew)
 
@@ -116,13 +116,13 @@ class NewAutoLboxDetector(object):
                     start = node.next_term
                     result = r.parse(start)
                     if r.possible_ends:
-                        for e, enddist in r.possible_ends:
+                        for e, enddist, split in r.possible_ends:
                             if e.lookup == "<ws>" or e.lookup == "<return>":
                                 continue
                             if self.contains_errornode(start, e, errornode):
-                               if self.parse_after_lbox_h2(lbox, e, start, pv):
+                               if self.parse_after_lbox_h2(lbox, e, start, pv, split):
                                         total_distance = self.abs_parse_distance + enddist
-                                        valid.append((start, e, sub, total_distance))
+                                        valid.append((start, e, sub, total_distance, split))
                 if node.lookup == "<return>" or type(node) is BOS:
                     break
                 node = node.prev_term
@@ -174,18 +174,18 @@ class NewAutoLboxDetector(object):
                             r.mode_limit_tokens_new = self.mode_limit_tokens_new
                             result = r.parse(term)
                             if r.possible_ends:
-                                for e, enddist in r.possible_ends:
+                                for e, enddist, split in r.possible_ends:
                                     if e.lookup in ws:
                                         continue
                                     if (self.contains_errornode(term, e, errornode) \
-                                            and self.parse_after_lbox_h2(lbox, e, parent, pv)):
+                                            and self.parse_after_lbox_h2(lbox, e, parent, pv, split)):
                                                 total_distance = self.abs_parse_distance + enddist
-                                                valid.append((term, e, sub, total_distance))
+                                                valid.append((term, e, sub, total_distance, split))
                                                 searched.add(term)
                 parent = parent.get_attr("parent", pv)
         return valid
 
-    def parse_after_lbox_h2(self, lbox, end, parent, version):
+    def parse_after_lbox_h2(self, lbox, end, parent, version, split=None):
         # XXX Can reuse preparsed ir as long as parent is the same
         root = parent.get_root(version)
         p, l = lang_dict[root.name].load()
@@ -195,7 +195,7 @@ class NewAutoLboxDetector(object):
             # anything
             ir.preparse(root, parent, version)
         # try parsing lbox + one more non-ws terminal
-        check = ir.parse_single(TextNode(lbox)) and ir.parse_after(end.next_term, distance=10)
+        check = ir.parse_single(TextNode(lbox)) and ir.parse_after(end.next_term, split, distance=10)
         self.abs_parse_distance = ir.abs_parse_distance
         return check
 
@@ -228,18 +228,18 @@ class NewAutoLboxDetector(object):
                         if r.possible_ends:
                             # Filter results and test if remaining file can be
                             # parsed after shifting the language box
-                            for e, enddist in r.possible_ends:
+                            for e, enddist, split in r.possible_ends:
                                 if e.lookup == "<ws>" or e.lookup == "<return>":
                                     continue
                                 if (self.contains_errornode(n, e, errornode) \
-                                    and self.parse_after_lbox_h1(lbox, e, cut, distance=10)) \
+                                    and self.parse_after_lbox_h1(lbox, e, cut, split=split, distance=10)) \
                                     or self.parse_after_lbox_h1(lbox, e, cut, errornode):
                                         # Either the error was solved by
                                         # moving it into the box or a box
                                         # was created before it, allowing
                                         # the error to be shifted
                                         total_distance = self.abs_parse_distance + enddist
-                                        valid.append((n, e, sub, total_distance))
+                                        valid.append((n, e, sub, total_distance, split))
                 cut = cut - 1
         return valid
 
@@ -252,7 +252,7 @@ class NewAutoLboxDetector(object):
             return True
         return False
 
-    def parse_after_lbox_h1(self, lbox, end, cut, errornode=None, distance=1):
+    def parse_after_lbox_h1(self, lbox, end, cut, errornode=None, split=None, distance=1):
         self.abs_parse_distance = 0
         parsed_tokens = 0
         # copy stack
@@ -265,7 +265,13 @@ class NewAutoLboxDetector(object):
         # count)
         lboxnode = TextNode(lbox)
         la = lboxnode
-        la.next_term = after_end
+        if split:
+            token = self.ol.lex(end.symbol.name[split:])
+            splitla = TextNode(Terminal(token[0][1]))
+            splitla.next_term = after_end
+            la.next_term = splitla
+        else:
+            la.next_term = after_end
         while True:
             if la.deleted:
                 la = la.next_term
@@ -331,6 +337,7 @@ class Recognizer(object):
         self.mode_limit_tokens_new = False
         self.abs_parse_distance = 0
         self.last_token_value = ""
+        self.last_split = 0
 
     def reset(self):
         self.state = [0]
@@ -360,7 +367,7 @@ class Recognizer(object):
                 self.state.append(element.action)
                 if self.is_finished() and self.last_read:
                     if self.mode_limit_tokens_new is False or self.last_read.version >= minversion:
-                        self.possible_ends.append((self.last_read, self.abs_parse_distance))
+                        self.possible_ends.append((self.last_read, self.abs_parse_distance, self.last_split))
                     self.last_read = None
                 token = self.next_token()
                 continue
@@ -383,6 +390,7 @@ class Recognizer(object):
             t = self.tokeniter()
             self.last_read = t[3][-1]
             self.last_token_value = t[0]
+            self.last_split = len(t[0]) - length
             return Terminal(t[1])
         except StopIteration:
             self.reached_eos = True
@@ -611,10 +619,15 @@ class IncrementalRecognizer(Recognizer):
                 return True
             node = node.next_term
 
-    def parse_after(self, la, distance=1):
+    def parse_after(self, la, split=None, distance=1):
         """Checks if la can be parsed in the current state. If la is whitespace,
         continue until we can parse the next non-whitespace token."""
         parsed_tokens = 0
+        if split:
+            token = self.lexer.lex(la.prev_term.symbol.name[split:])
+            tmpla = la
+            la = TextNode(Terminal(token[0][1]))
+            la.next_term = tmpla
         while True:
             lookup = get_lookup(la)
             element = self.syntaxtable.lookup(self.state[-1], lookup)

--- a/lib/eco/autolboxdetector.py
+++ b/lib/eco/autolboxdetector.py
@@ -390,7 +390,7 @@ class Recognizer(object):
             t = self.tokeniter()
             self.last_read = t[3][-1]
             self.last_token_value = t[0]
-            self.last_split = len(t[0]) - length
+            self.last_split = t[4]
             return Terminal(t[1])
         except StopIteration:
             self.reached_eos = True

--- a/lib/eco/editortab.py
+++ b/lib/eco/editortab.py
@@ -376,7 +376,7 @@ class AutoLBoxComplete(QFrame):
                         temp = temp.next_term
                     text.append(e.symbol.name[:split] if split<0 else e.symbol.name)
                     text.append(" : {}".format(l))
-                item = QAction("".join(text), menu)
+                item = QAction("".join(text).replace("&", "&&"), menu)
                 item.setData((s,e,l,split))
                 menu.addAction(item)
             action = menu.exec_(self.mapToGlobal(event.pos()))

--- a/lib/eco/editortab.py
+++ b/lib/eco/editortab.py
@@ -364,7 +364,7 @@ class AutoLBoxComplete(QFrame):
             menu = QMenu(self)
             if line not in self.parent().editor.autolboxlines:
                 return
-            for s, e, l in self.parent().editor.autolboxlines[line]:
+            for s, e, l, split in self.parent().editor.autolboxlines[line]:
                 text = []
                 if type(s.symbol) is MagicTerminal:
                     temp = s.symbol.ast.children[0].next_term
@@ -374,18 +374,18 @@ class AutoLBoxComplete(QFrame):
                     while temp is not e:
                         text.append(temp.symbol.name)
                         temp = temp.next_term
-                    text.append(e.symbol.name)
+                    text.append(e.symbol.name[:split] if split<0 else e.symbol.name)
                     text.append(" : {}".format(l))
                 item = QAction("".join(text), menu)
-                item.setData((s,e,l))
+                item.setData((s,e,l,split))
                 menu.addAction(item)
             action = menu.exec_(self.mapToGlobal(event.pos()))
             if action:
-                s, e, l = action.data().toPyObject()
+                s, e, l, split = action.data().toPyObject()
                 if type(s.symbol) is MagicTerminal:
                     self.parent().editor.tm.expand_languagebox(s, e, manual=True)
                 else:
-                    self.parent().editor.tm.select_nodes(s, e)
+                    self.parent().editor.tm.select_from_to(s, e, split)
                     langdef = self.parent().editor.tm.get_langdef_from_string(l)
                     self.parent().editor.tm.surround_with_languagebox(langdef)
                 self.parent().editor.tm.reparse(s)

--- a/lib/eco/inclexer/test/test_inclexer.py
+++ b/lib/eco/inclexer/test/test_inclexer.py
@@ -85,11 +85,11 @@ class Test_CalcLexer(Test_IncrementalLexer):
         bos.insert_after(new)
 
         next_token = self.lexer.lexer.get_token_iter(new).next
-        assert next_token() == ("1", "INT", 1, [TextNode(Terminal("1+2*3"))])
-        assert next_token() == ("+", "plus", 0, [TextNode(Terminal("1+2*3"))])
-        assert next_token() == ("2", "INT", 1, [TextNode(Terminal("1+2*3"))])
-        assert next_token() == ("*", "mul", 0, [TextNode(Terminal("1+2*3"))])
-        assert next_token() == ("3", "INT", 1, [TextNode(Terminal("1+2*3"))])
+        assert next_token() == ("1", "INT", 1, [TextNode(Terminal("1+2*3"))], -4)
+        assert next_token() == ("+", "plus", 0, [TextNode(Terminal("1+2*3"))], -3)
+        assert next_token() == ("2", "INT", 1, [TextNode(Terminal("1+2*3"))], -2)
+        assert next_token() == ("*", "mul", 0, [TextNode(Terminal("1+2*3"))], -1)
+        assert next_token() == ("3", "INT", 1, [TextNode(Terminal("1+2*3"))], 0)
 
     def test_token_iter2(self):
         ast = AST()
@@ -101,7 +101,7 @@ class Test_CalcLexer(Test_IncrementalLexer):
         new.insert_after(new2)
 
         next_token = self.lexer.lexer.get_token_iter(new).next
-        assert next_token() == ("1234", "INT", 1, [TextNode(Terminal("12")), TextNode(Terminal("34"))])
+        assert next_token() == ("1234", "INT", 1, [TextNode(Terminal("12")), TextNode(Terminal("34"))], 0)
 
     def test_token_iter_lbox(self):
         lexer = IncrementalLexer("""
@@ -118,9 +118,9 @@ class Test_CalcLexer(Test_IncrementalLexer):
         new2.insert_after(new3)
 
         next_token = lexer.lexer.get_token_iter(new).next
-        assert next_token() == ("12", "INT", 1, [TextNode(Terminal("12"))])
-        assert next_token() == (lbph, "", 0, [TextNode(MagicTerminal("<SQL>"))])
-        assert next_token() == ("34", "INT", 1, [TextNode(Terminal("34"))])
+        assert next_token() == ("12", "INT", 1, [TextNode(Terminal("12"))], 0)
+        assert next_token() == (lbph, "", 0, [TextNode(MagicTerminal("<SQL>"))], 0)
+        assert next_token() == ("34", "INT", 1, [TextNode(Terminal("34"))], 0)
 
     def test_token_iter_lbox_multi(self):
         lexer = IncrementalLexer("""
@@ -138,7 +138,7 @@ class Test_CalcLexer(Test_IncrementalLexer):
         new2.insert_after(new3)
 
         next_token = lexer.lexer.get_token_iter(new).next
-        assert next_token() == (["\"abc",lbph,"def\""], "STRING", 0, [TextNode(Terminal("\"abc")), TextNode(MagicTerminal("<SQL>")), TextNode(Terminal("def\""))])
+        assert next_token() == (["\"abc",lbph,"def\""], "STRING", 0, [TextNode(Terminal("\"abc")), TextNode(MagicTerminal("<SQL>")), TextNode(Terminal("def\""))], 0)
 
     def test_token_iter_lbox_x80(self):
         lexer = IncrementalLexer("""
@@ -156,7 +156,7 @@ class Test_CalcLexer(Test_IncrementalLexer):
         new2.insert_after(new3)
 
         next_token = lexer.lexer.get_token_iter(new).next
-        assert next_token() == ("\"abc\x80def\"", "STRING", 0, [TextNode(Terminal("\"abc")), TextNode(Terminal("\x80")), TextNode(Terminal("def\""))])
+        assert next_token() == ("\"abc\x80def\"", "STRING", 0, [TextNode(Terminal("\"abc")), TextNode(Terminal("\x80")), TextNode(Terminal("def\""))], 0)
 
     def test_relex(self):
         ast = AST()

--- a/lib/eco/test/test_eco.py
+++ b/lib/eco/test/test_eco.py
@@ -5389,6 +5389,32 @@ public static int contents = {
             print("input", c)
             treemanager.key_normal(c)
 
+    def test_java_php_slashslash_bug(self):
+        grm = load_json_grammar("test/javaphp_expr.json")
+        parser, lexer = grm.load()
+        parser.setup_autolbox(grm.name, lexer)
+        treemanager = TreeManager()
+        treemanager.option_autolbox_insert = True
+        treemanager.add_parser(parser, lexer, "")
+        assert len(treemanager.parsers) == 1
+        p = """class C {
+int x = 1;
+}"""
+        treemanager.import_file(p)
+        assert len(treemanager.parsers) == 1
+        assert parser.last_status == True
+
+        treemanager.key_cursors(DOWN)
+        treemanager.key_end()
+        treemanager.key_cursors(LEFT);
+        treemanager.key_backspace()
+        for c in "$this . 'http://":
+            treemanager.key_normal(c)
+        print("\n\n\n\n")
+        treemanager.key_normal("'")
+        assert parser.last_status is True
+        assert len(treemanager.parsers) == 2
+
     @pytest.mark.skipif("TRAVIS" in os.environ and os.environ["TRAVIS"] == "true", reason="Sqlite takes too long to built on Travis. Skip!")
     def test_lua_sqlite_expand(self):
         grm = load_json_grammar("test/luasqlite_expr.json")

--- a/lib/eco/test/test_eco.py
+++ b/lib/eco/test/test_eco.py
@@ -5410,7 +5410,6 @@ int x = 1;
         treemanager.key_backspace()
         for c in "$this . 'http://":
             treemanager.key_normal(c)
-        print("\n\n\n\n")
         treemanager.key_normal("'")
         assert parser.last_status is True
         assert len(treemanager.parsers) == 2

--- a/lib/eco/treelexer/lexer.py
+++ b/lib/eco/treelexer/lexer.py
@@ -537,7 +537,7 @@ class Lexer(object):
             lookahead = 0
             oldpos = pos
             oldnode = node
-            result = ("", None, -1, None)
+            result = ("", None, -1, None, 0)
             while type(node.symbol) is IndentationTerminal:
                 node = node.next_term
             if type(node) is MultiTextNode:
@@ -550,7 +550,7 @@ class Lexer(object):
                     read = [node.parent]
                 else:
                     read = [node]
-                yield (lbph, "", 0, read)
+                yield (lbph, "", 0, read, 0)
                 if node.next_term is None and node.ismultichild():
                     node = node.parent.next_term
                 else:
@@ -560,7 +560,12 @@ class Lexer(object):
                 token = pm.match(p, node, pos)
                 lookahead = max(pm.la, lookahead)
                 if token and self.tlen(token) > self.tlen(result[0]): # find longest match
-                    result = (token, n, lookahead - pm.scanned_chars, pm.read_nodes)
+                    if pm.pos > 0 and pm.pos != len(pm.text.symbol.name):
+                        # Record when a node only produced a partial match
+                        split = pm.pos - len(pm.text.symbol.name)
+                    else:
+                        split = 0
+                    result = (token, n, lookahead - pm.scanned_chars, pm.read_nodes, split)
                     progress = pm.pos, pm.text
                     continue
                 else:

--- a/lib/eco/treelexer/test_lexer.py
+++ b/lib/eco/treelexer/test_lexer.py
@@ -339,11 +339,11 @@ class Test_IncrementalLexing(object):
         bos.insert_after(new)
 
         it = self.lexer.get_token_iter(new)
-        assert it.next() == ("1", "INT", 1, [TextNode(Terminal("1+2*3"))])
-        assert it.next() == ("+", "plus", 0, [TextNode(Terminal("1+2*3"))])
-        assert it.next() == ("2", "INT", 1, [TextNode(Terminal("1+2*3"))])
-        assert it.next() == ("*", "mul", 0, [TextNode(Terminal("1+2*3"))])
-        assert it.next() == ("3", "INT", 1, [TextNode(Terminal("1+2*3"))])
+        assert it.next() == ("1", "INT", 1, [TextNode(Terminal("1+2*3"))], -4)
+        assert it.next() == ("+", "plus", 0, [TextNode(Terminal("1+2*3"))], -3)
+        assert it.next() == ("2", "INT", 1, [TextNode(Terminal("1+2*3"))], -2)
+        assert it.next() == ("*", "mul", 0, [TextNode(Terminal("1+2*3"))], -1)
+        assert it.next() == ("3", "INT", 1, [TextNode(Terminal("1+2*3"))], 0)
         with pytest.raises(StopIteration):
             it.next()
 
@@ -355,7 +355,7 @@ class Test_IncrementalLexing(object):
         bos.insert_after(new)
 
         it = self.lexer.get_token_iter(new)
-        assert it.next() == ("1", "INT", 1, [TextNode(Terminal("1b"))])
+        assert it.next() == ("1", "INT", 1, [TextNode(Terminal("1b"))], -1)
         with pytest.raises(LexingError):
             it.next()
 
@@ -371,9 +371,9 @@ class Test_IncrementalLexing(object):
         new2.insert_after(new3)
 
         it = self.lexer.get_token_iter(new)
-        assert it.next() == ("12", "INT", 1, [TextNode(Terminal("12"))])
-        assert it.next() == (lbph, "", 0, [TextNode(MagicTerminal("<SQL>"))])
-        assert it.next() == ("34", "INT", 1, [TextNode(Terminal("34"))])
+        assert it.next() == ("12", "INT", 1, [TextNode(Terminal("12"))], 0)
+        assert it.next() == (lbph, "", 0, [TextNode(MagicTerminal("<SQL>"))], 0)
+        assert it.next() == ("34", "INT", 1, [TextNode(Terminal("34"))], 0)
         with pytest.raises(Exception):
             it.next()
 
@@ -391,8 +391,8 @@ class Test_IncrementalLexing(object):
         new3.insert_after(new4)
 
         it = self.lexer.get_token_iter(new)
-        assert it.next() == ("12", "INT", 1, [TextNode(Terminal("12"))])
-        assert it.next() == (["'string with", lbph, "inside'"], "string", 0, [TextNode(Terminal("'string with")), TextNode(MagicTerminal("<SQL>")), TextNode(Terminal("inside'"))])
+        assert it.next() == ("12", "INT", 1, [TextNode(Terminal("12"))], 0)
+        assert it.next() == (["'string with", lbph, "inside'"], "string", 0, [TextNode(Terminal("'string with")), TextNode(MagicTerminal("<SQL>")), TextNode(Terminal("inside'"))], 0)
         with pytest.raises(StopIteration):
             it.next()
 
@@ -412,7 +412,7 @@ class Test_IncrementalLexing(object):
         new4.insert_after(new5)
 
         it = self.lexer.get_token_iter(new1)
-        assert it.next() == (["'a", lbph, "b", lbph, "c'"], "string", 0, [TextNode(Terminal("'a")), TextNode(MagicTerminal("<SQL>")), TextNode(Terminal("b")), TextNode(MagicTerminal("<SQL>")), TextNode(Terminal("c'"))])
+        assert it.next() == (["'a", lbph, "b", lbph, "c'"], "string", 0, [TextNode(Terminal("'a")), TextNode(MagicTerminal("<SQL>")), TextNode(Terminal("b")), TextNode(MagicTerminal("<SQL>")), TextNode(Terminal("c'"))], 0)
         with pytest.raises(StopIteration):
             it.next()
 
@@ -428,7 +428,7 @@ class Test_IncrementalLexing(object):
         new2.insert_after(new3)
 
         it = self.lexer.get_token_iter(new1)
-        assert it.next() == (["'a", "\r", "b'"], "string", 0, [TextNode(Terminal("'a")), TextNode(Terminal("\r")), TextNode(Terminal("b'"))])
+        assert it.next() == (["'a", "\r", "b'"], "string", 0, [TextNode(Terminal("'a")), TextNode(Terminal("\r")), TextNode(Terminal("b'"))], 0)
         with pytest.raises(StopIteration):
             it.next()
 
@@ -448,7 +448,7 @@ class Test_IncrementalLexing(object):
         new4.insert_after(new5)
 
         it = self.lexer.get_token_iter(new1)
-        assert it.next() == (["'a", "\r", "b", lbph, "c'"], "string", 0, [TextNode(Terminal("'a")), TextNode(Terminal("\r")), TextNode(Terminal("b")), TextNode(MagicTerminal("<SQL>")), TextNode(Terminal("c'"))])
+        assert it.next() == (["'a", "\r", "b", lbph, "c'"], "string", 0, [TextNode(Terminal("'a")), TextNode(Terminal("\r")), TextNode(Terminal("b")), TextNode(MagicTerminal("<SQL>")), TextNode(Terminal("c'"))], 0)
         with pytest.raises(StopIteration):
             it.next()
 
@@ -467,7 +467,7 @@ class Test_TripleQuote(object):
         new = TextNode(Terminal('"""abc"""'))
         ast.parent.children[0].insert_after(new)
         it = self.lexer.get_token_iter(new)
-        assert it.next() == ('"""abc"""', "MLS", 0, [TextNode(Terminal('"""abc"""'))])
+        assert it.next() == ('"""abc"""', "MLS", 0, [TextNode(Terminal('"""abc"""'))], 0)
 
     def test_simple2(self):
         ast = AST()
@@ -475,7 +475,7 @@ class Test_TripleQuote(object):
         new = TextNode(Terminal('""'))
         ast.parent.children[0].insert_after(new)
         it = self.lexer.get_token_iter(new)
-        assert it.next() == ('""', "dstring", 1, [TextNode(Terminal('""'))])
+        assert it.next() == ('""', "dstring", 1, [TextNode(Terminal('""'))], 0)
 
     def test_simple3(self):
         ast = AST()
@@ -483,7 +483,7 @@ class Test_TripleQuote(object):
         new = TextNode(Terminal('"""'))
         ast.parent.children[0].insert_after(new)
         it = self.lexer.get_token_iter(new)
-        assert it.next() == ('""', "dstring", 2, [TextNode(Terminal('"""'))])
+        assert it.next() == ('""', "dstring", 2, [TextNode(Terminal('"""'))], -1)
 
     def test_simple4(self):
         ast = AST()
@@ -491,8 +491,8 @@ class Test_TripleQuote(object):
         new = TextNode(Terminal('"""abc""d'))
         ast.parent.children[0].insert_after(new)
         it = self.lexer.get_token_iter(new)
-        assert it.next() == ('""', "dstring", 7, [TextNode(Terminal('"""abc""d'))])
-        assert it.next() == ('"abc"', "dstring", 0, [TextNode(Terminal('"""abc""d'))])
+        assert it.next() == ('""', "dstring", 7, [TextNode(Terminal('"""abc""d'))], -7)
+        assert it.next() == ('"abc"', "dstring", 0, [TextNode(Terminal('"""abc""d'))], -2)
 
 class Test_Keyword(object):
 
@@ -508,7 +508,7 @@ class Test_Keyword(object):
         new = TextNode(Terminal("asd"))
         ast.parent.children[0].insert_after(new)
         it = self.lexer.get_token_iter(new)
-        assert it.next() == ("asd", "NAME", 1, [TextNode(Terminal("asd"))])
+        assert it.next() == ("asd", "NAME", 1, [TextNode(Terminal("asd"))], 0)
 
 class Test_LuaComments(object):
 
@@ -525,7 +525,7 @@ class Test_LuaComments(object):
         new = TextNode(Terminal('--[[testtest]]'))
         ast.parent.children[0].insert_after(new)
         it = self.lexer.get_token_iter(new)
-        assert it.next() == ('--[[testtest]]', "mcomment", 0, [TextNode(Terminal('--[[testtest]]'))])
+        assert it.next() == ('--[[testtest]]', "mcomment", 0, [TextNode(Terminal('--[[testtest]]'))], 0)
 
     def test_lookahead(self):
         ast = AST()
@@ -533,7 +533,7 @@ class Test_LuaComments(object):
         new = TextNode(Terminal('--[[test\rtest'))
         ast.parent.children[0].insert_after(new)
         it = self.lexer.get_token_iter(new)
-        assert it.next() == ('--[[test', "scomment", 6, [TextNode(Terminal('--[[test\rtest'))])
+        assert it.next() == ('--[[test', "scomment", 6, [TextNode(Terminal('--[[test\rtest'))], -5)
 
     def test_multi(self):
         ast = AST()
@@ -541,4 +541,4 @@ class Test_LuaComments(object):
         new = TextNode(Terminal('--[[test\rtest]]'))
         ast.parent.children[0].insert_after(new)
         it = self.lexer.get_token_iter(new)
-        assert it.next() == (['--[[test', '\r', 'test]]'], "mcomment", 0, [TextNode(Terminal('--[[test\rtest]]'))])
+        assert it.next() == (['--[[test', '\r', 'test]]'], "mcomment", 0, [TextNode(Terminal('--[[test\rtest]]'))], 0)

--- a/lib/eco/treemanager.py
+++ b/lib/eco/treemanager.py
@@ -1342,11 +1342,12 @@ class TreeManager(object):
         self.cursor.line = len(self.lines) - 1
         self.selection_end = self.cursor.copy()
 
-    def select_from_to(self, _from, _to):
+    def select_from_to(self, _from, _to, split):
         self.cursor.move_to_node(_from)
         self.selection_start = self.cursor.copy()
         self.cursor.move_to_node(_to, after=True)
         self.selection_end = self.cursor.copy()
+        self.selection_end.pos += split
 
     def get_all_annotations_with_hint(self, hint):
         """Return all annotations (optionally of a specific type).
@@ -2182,11 +2183,11 @@ class TreeManager(object):
             # apply language boxes if there is only one choice
             for n in p.error_nodes:
                 if not n.deleted and n.autobox and len(n.autobox) == 1:
-                    s, e, l = n.autobox[0]
+                    s, e, l, split = n.autobox[0]
                     self.undo_snapshot()
                     ctemp = self.cursor.get_x()
                     ltemp = self.cursor.line
-                    self.select_from_to(s, e)
+                    self.select_from_to(s, e, split)
                     self.skipautolbox = True # block automatic lboxes during automatic insertion
                     self.surround_with_languagebox(lang_dict[l], True)
                     self.cursor.line = ltemp
@@ -2218,7 +2219,7 @@ class TreeManager(object):
         r2.preparse(outer_root, lbox)
         r2.parse_after(lbox)
         filtered = []
-        for e, _ in r.possible_ends:
+        for e, _, _ in r.possible_ends:
             if e.lookup == "<ws>" or e.lookup == "<return>":
                 continue
             tmp = r2.state[:]


### PR DESCRIPTION
b0e07b1 enables automatic language boxes to be inserted, even if they lead to an existing token needing to be split up. For an example, see the test where a PHP insertion which contains a partial Java comment `//';` is split up  after the `;` to allow the insertion of a language box.

e9dc904 For this to work properly we need to record within the lexer when a node only returned a partial match and forward this information to the automatic language box detector.