### PR TITLE
Better ranking

### DIFF
--- a/lib/eco/test/test_eco.py
+++ b/lib/eco/test/test_eco.py
@@ -5173,6 +5173,32 @@ WHERE ProductID IN (SELECT ProductID FROM OrderDetails WHERE Quantity = 10);"""
         assert len(treemanager.parsers) == 2
         assert parser.last_status == True
 
+    def test_java_sql_ranking(self):
+        p = """class C {
+int x = 1, y = 2;
+int y = 1 + 2 * 3;
+int z = 4 + 5 - 6;
+}"""
+
+        parser, lexer = javasql.load()
+        parser.setup_autolbox(javasql.name, lexer)
+        treemanager = TreeManager()
+        treemanager.option_autolbox_insert = True
+        treemanager.add_parser(parser, lexer, "")
+
+        for c in p:
+            treemanager.key_normal(c)
+
+        treemanager.key_cursors(UP)
+        treemanager.key_cursors(UP)
+        treemanager.key_cursors(UP)
+        treemanager.key_end()
+        for i in range(8): treemanager.key_cursors(LEFT)
+        treemanager.key_backspace()
+        for s in "SELECT a":
+            treemanager.key_normal(s)
+        assert len(parser.error_nodes[0].autobox) == 2
+
     def test_php_python_autoremove(self):
         """Sometimes automatically inserted boxes are valid in both languages.
         Previously we only autoremoved boxes that were invalid. However, we


### PR DESCRIPTION
**Not ready for review:** I will do an experiment run to see how this changes our tables and add the observations here.

This PR improves the ranking of automatic languagebox candidates.

Previously, candidates were ranked by the absolute distance they allow parsing to continue. Since this distance had a cut-off of 10 tokens, this gave candidates that occur later in the program an unfair advantage.

We can improve this by taking the candidate that is most likely to parse furthest (i.e. the candidate whose ending boundary reaches the furthest) and check how far it allows parsing to continue (keeping a cut-off of 10 tokens). We then check for each of the remaining candidates if they can parse as far (or further) than that. If they do they are also equally valid candidates. If not, they are worse and are removed from the list of candidates presented to the user.