### PR TITLE
Heuristic runtime

### DIFF
--- a/lib/eco/autolboxdetector.py
+++ b/lib/eco/autolboxdetector.py
@@ -113,7 +113,6 @@ class NewAutoLboxDetector(object):
 
     def heuristic_line(self, errornode):
         valid = []
-        pv = self.op.prev_version
         for sub in self.langs:
             lbox = MagicTerminal("<{}>".format(sub))
             node = errornode.prev_term
@@ -129,7 +128,7 @@ class NewAutoLboxDetector(object):
                             if e.lookup == "<ws>" or e.lookup == "<return>":
                                 continue
                             valid.append((start, e, sub, enddist, split, lbox, errornode))
-                if node.lookup == "<return>" or type(node) is BOS:
+                if node.lookup == "<return>" or type(node) is BOS or node.ismultinode():
                     break
                 node = node.prev_term
         return valid

--- a/lib/eco/incparser/astree.py
+++ b/lib/eco/incparser/astree.py
@@ -298,6 +298,9 @@ class Node(object):
     def ismultichild(self):
         return isinstance(self.parent, MultiTextNode)
 
+    def ismultinode(self):
+        return type(self) is MultiTextNode
+
     def insert_after_node(self, node, newnode):
         i = 0
         for c in self.children:


### PR DESCRIPTION
This PR contains two optimisations that reduce the runtime of the heuristics, removing a worst-case scenario of over 3s for a single keypress in our experiment, and replacing it with a worst-case of 0.13s, which is also the only average going above 0.1s.

However, I noticed that one of the optimisations changes the outcome of the stack heuristic for a specific composition, which is why I disabled it again (see comment). I would prefer to leave it in as ac omment though as it might be useful in the future, but can be convinced otherwise.