### PR TITLE
Addition to docs, fix in JsonManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ distributed under a BSD/MIT license.
 ### Install ###
 At a minimum you will need to install:
 
-* Python 3 https://www.python.org/download/
+* Python 2 **and** 3 https://www.python.org/download/
 * PyQt5 http://www.riverbankcomputing.co.uk/software/pyqt/download5
 * Py http://py.readthedocs.io/en/latest/install.html
 
@@ -26,8 +26,8 @@ If you wish to see visualisations of parse trees, you may optionally install:
 The above dependencies can be installed as follows on command line:
 
 ```
-# Get Python3 if you haven't already
-sudo apt-get install python3
+# Get Python 2 *and* 3 if you haven't already
+sudo apt-get install python python3
 
 python3 -m pip install --user PyQt5 py
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,24 @@ If you wish to see visualisations of parse trees, you may optionally install:
 * PyDot https://code.google.com/p/pydot/
 * Pygame https://www.pygame.org/
 
+#### On Ubuntu (including Windows Subsysten for Linux) ####
+
+The above dependencies can be installed as follows on command line:
+
+```
+# Get Python3 if you haven't already
+sudo apt-get install python3
+
+python3 -m pip install --user PyQt5 py
+
+# I couldn't run Eco without it because Qt couldn't find a platform plugin
+# Solution from https://forum.qt.io/topic/99562/qt-5-12-1-cannot-load-library-opt-qt-5-12-1-gcc_64-plugins-platforms-libqxcb-so-libxkbcommon-x11-so-0-cannot-open-shared-object-file-no-such-file-or-directory
+sudo apt-get install libxkbcommon-x11-0
+
+# Optional dependencies if you want to visualize parse trees
+sudo apt-get install graphviz 
+python3 -m pip install --user pydot pygame
+```
 
 ### Running Eco ###
 

--- a/lib/eco/jsonmanager.py
+++ b/lib/eco/jsonmanager.py
@@ -48,12 +48,12 @@ class JsonManager(object):
 
     def load(self, filename):
         try:
-            z = gzip.open(str(filename), "rb")
+            z = gzip.open(str(filename), "rt", encoding="utf-8")
             main = json.loads(z.read())
             z.close()
         except IOError:
             # backwards compatibility
-            fp = open(filename, "r")
+            fp = open(filename, "r", encoding="utf-8")
             main = json.load(fp)
             fp.close()
 

--- a/tutorial/TUTORIAL.md
+++ b/tutorial/TUTORIAL.md
@@ -5,15 +5,16 @@ This tutorial will help you explore a simple use case for Eco.
 ### Installation
 
 Depending on how your version of Python was built, you may need to install
-SQLite separately. To determine whether you need to do so, type "python2.7" at
-the command line and then "import sqlite3". If that does not produce an error,
-you can skip installation. Otherwise, you will need to install SQLite from
-http://www.sqlite.org/download.html
+SQLite separately. To determine whether you need to do so, run `python3 -c "import sqlite3"`
+on your command line. On success, nothing shall be printed. On failure, you probably
+get an error messaging indicating that SQLite on your system is missing. In the latter case,
+you will need to install SQLite from http://www.sqlite.org/download.html or your OS's package
+manager.
 
-You will then to generate a test database by executing these commands:
+You will then need to generate a test database by executing these commands:
 ```
   $ wget https://bitbucket.org/softdevteam/eco/downloads/gendb.py
-  $ python2.7 gendb.py
+  $ python3 gendb.py
 ```
 You can then run Eco in the normal way.
 
@@ -92,8 +93,10 @@ Now we can export our program using "File->Export" and saving it as "web.py"
 (make sure it is saved in the same location where you stored and executed
 'gendb.py'). Afterwards we can run it:
 ```
-    python2.7 web.py > web.html
+    python2 web.py > web.html
 ```
+Note that we need Python 2 here as Eco still generated Python 2 files.
+
 Opening the resulting file "web.html" in a browser should now list people from
 the SQL database.
 


### PR DESCRIPTION
I added further install instructions to the readme such that Ubuntu and WSL users (like me) can directly all necessary packages without diving into the web.

Furthermore, I always got
```
TypeError: the JSON object must be str, not 'bytes'
Traceback (most recent call last):
  File "eco.py", line 1157, in newfile
    etab.set_language(lang, lview.getWhitespace())
  File "/.../eco/lib/eco/editortab.py", line 121, in set_language
    incparser, inclexer = lang.load()
  File "/.../eco/lib/eco/grammars/grammars.py", line 85, in load
    root, language, whitespaces = manager.load(self.filename)[0]
  File "/.../eco/lib/eco/jsonmanager.py", line 52, in load
    main = json.loads(z.read())
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
```
on starting Eco. I fixed that in JsonManager, see the small diff.