### PR TITLE
Minimally unbreak PyHyp export.

### DIFF
--- a/lib/eco/eco.py
+++ b/lib/eco/eco.py
@@ -1695,9 +1695,9 @@ class SubProcessThread(QThread):
                 self.signal_execute_fail.emit("program syntactically invalid")
             else:
                 for line in iter(p.stdout.readline, b''):
-                    if lang == "PHP + Python" and line.startswith("  <?php{ "):
-                            line = "  " + line[9:]
-                    self.signal.emit(line.rstrip())
+                    if lang == "PHP + Python" and line.startswith(b"  <?php{ "):
+                        line = b"  " + line[9:]
+                    self.signal.emit(line.rstrip().decode("utf-8"))
         except ExecutionError as e:
             self.signal_execute_fail.emit(e.message)
 

--- a/lib/eco/treemanager.py
+++ b/lib/eco/treemanager.py
@@ -2057,10 +2057,11 @@ class TreeManager(object):
                 f = (os.open(d + "/" + f, os.O_RDWR|os.O_CREAT), d + "/" + f)
             else:
                 f = tempfile.mkstemp(dir=d)
-            os.write(f[0], PHPPython.export(self.get_bos(), os.path.basename(source)))
+            with open(f[0], "w") as fw:
+                fw.write(PHPPython.export(self.get_bos(), os.path.basename(source)))
             settings = QSettings("softdev", "Eco")
-            prefixpath = str(settings.value("env_pypyprefix", "").toString())
-            pyhyppath = str(settings.value("env_pyhyp", "").toString())
+            prefixpath = settings.value("env_pypyprefix", "")
+            pyhyppath = settings.value("env_pyhyp", "")
             if pyhyppath:
                 if prefixpath:
                     env = os.environ.copy()


### PR DESCRIPTION
There are a couple of problems here both, I think, related to Python 3's mind-boggling bytes/str split. This commit bodges things so that I can at least run PyHyp programs again.