### PR TITLE
Add troubleshooting section for Windows Subsystem for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,31 @@ If you wish to see visualisations of parse trees, you may optionally install:
 * PyDot https://code.google.com/p/pydot/
 * Pygame https://www.pygame.org/
 
-
 ### Running Eco ###
 
 To run Eco, use the bin/eco file:
 
   `$ bin/eco`
-  
+
 ### Tutorial ###
 
 A small tutorial to get you started with the basics of Eco can be found [here](tutorial/TUTORIAL.md).
+
+### Troubleshooting ###
+
+#### Windows Subsystem for Linux running Ubuntu ####
+
+If you are having trouble running Eco on the Windows Subsystem running Ubuntu,
+follow these instructions:
+
+```
+# Install Python3
+sudo apt-get install python3 libxkbcommon-x11-0
+
+# Install dependencies via pip
+python3 -m pip install --user PyQt5 py
+
+# Optional dependencies to visualise parse trees
+sudo apt-get install graphviz
+python3 -m pip install --user pydot pygame
+```

--- a/tutorial/TUTORIAL.md
+++ b/tutorial/TUTORIAL.md
@@ -1,19 +1,22 @@
 ## Tutorial
 
 This tutorial will help you explore a simple use case for Eco.
+Note that while Eco runs on Python3, it still parses and exports Python2
+programs. In order to complete this tutorial, make sure you have also installed
+Python2.
 
 ### Installation
 
 Depending on how your version of Python was built, you may need to install
-SQLite separately. To determine whether you need to do so, type "python2.7" at
-the command line and then "import sqlite3". If that does not produce an error,
-you can skip installation. Otherwise, you will need to install SQLite from
-http://www.sqlite.org/download.html
+SQLite separately. To determine whether you need to do so, run `python2 -c
+"import sqlite3"` on your command line. If you get an error message indicating
+that SQLite is missing on your system, you will need to install SQLite from
+http://www.sqlite.org/download.html or via your OS's package manager.
 
-You will then to generate a test database by executing these commands:
+You will then need to generate a test database by executing these commands:
 ```
   $ wget https://bitbucket.org/softdevteam/eco/downloads/gendb.py
-  $ python2.7 gendb.py
+  $ python2 gendb.py
 ```
 You can then run Eco in the normal way.
 
@@ -92,8 +95,9 @@ Now we can export our program using "File->Export" and saving it as "web.py"
 (make sure it is saved in the same location where you stored and executed
 'gendb.py'). Afterwards we can run it:
 ```
-    python2.7 web.py > web.html
+    python2 web.py > web.html
 ```
+
 Opening the resulting file "web.html" in a browser should now list people from
 the SQL database.
 


### PR DESCRIPTION
I added further install instructions to the readme such that Ubuntu and WSL users (like me) can directly all necessary packages without diving into the web.

Split from originally larger PR #271.