### PR TITLE
Passing options stops "open file" crashing.

### DIFF
--- a/lib/eco/eco.py
+++ b/lib/eco/eco.py
@@ -1284,7 +1284,9 @@ class Window(QMainWindow):
 
     def openfile(self, filename=None):
         if not filename:
-            filename, _ = QFileDialog.getOpenFileName(self, "Open File", self.get_last_dir(), "Eco files (*.eco *.nb *.eco.bak);; All files (*.*)")
+            options = QFileDialog.Options()
+            options |= QFileDialog.DontUseNativeDialog
+            filename, _ = QFileDialog.getOpenFileName(self, "Open File", self.get_last_dir(), "Eco files (*.eco *.nb *.eco.bak);; All files (*.*)", options=options)
         if filename:
             self.save_last_dir(str(filename))
             self.add_to_recent_files(str(filename))


### PR DESCRIPTION
Without this fix, "open file" crashes and spits out many warnings along the lines of:

```
  (python3:74918): Gtk-CRITICAL **: 09:07:59.313: gtk_button_box_get_layout: assertion 'GTK_IS_BUTTON_BOX (widget)' failed
```

A quick hunt online suggests this might be because we don't quite call the underlying C API correctly, but this fix that I cobbled together seems to do the trick at least in this limited case.