### PR TITLE
Fix crashes due to API changes in pyqt.

### DIFF
--- a/lib/eco/editortab.py
+++ b/lib/eco/editortab.py
@@ -140,9 +140,9 @@ class ScopeScrollArea(QAbstractScrollArea):
 
     def update(self):
         QWidget.update(self)
-        self.verticalScrollBar().setMaximum(self.parent().editor.scroll_height)
+        self.verticalScrollBar().setMaximum(int(self.parent().editor.scroll_height))
         self.verticalScrollBar().setPageStep(50)
-        self.horizontalScrollBar().setMaximum(self.parent().editor.scroll_width)
+        self.horizontalScrollBar().setMaximum(int(self.parent().editor.scroll_width))
         self.horizontalScrollBar().setPageStep(50)
 
 
@@ -334,7 +334,7 @@ class LineNumbers(QFrame):
         breakpoint_space = 0
         if self.parent().debugging:
             breakpoint_space = 10
-        self.setMinimumWidth(gfont.fontwt * (digits + 1) + breakpoint_space)
+        self.setMinimumWidth(int(gfont.fontwt * (digits + 1) + breakpoint_space))
         QFrame.update(self)
 
 class AutoLBoxComplete(QFrame):

--- a/lib/eco/nodeeditor.py
+++ b/lib/eco/nodeeditor.py
@@ -670,10 +670,12 @@ class NodeEditor(QFrame):
         colorhex = self.palette().color(QPalette.Text)
         pen.setColor(QColor(colorhex))
         paint.setPen(pen)
-        draw_cursor_at = QRect(x, y, 0, self.fontht - 3)
+        draw_cursor_at = QRect(int(x), int(y), 0, self.fontht - 3)
         paint.drawRect(draw_cursor_at)
 
     def draw_vertical_squiggly_line(self, paint, x, y):
+        x = int(x)
+        y = int(y)
         paint.setPen(Qt.CustomDashLine)
         pen = paint.pen()
         pen.setColor(QColor("red"))
@@ -690,6 +692,9 @@ class NodeEditor(QFrame):
         paint.setPen(Qt.SolidLine)
 
     def draw_squiggly_line(self, paint, x, y, length, color):
+        x = int(x)
+        y = int(y)
+        length = int(length)
         paint.setPen(Qt.CustomDashLine)
         pen = paint.pen()
         pen.setColor(QColor(color))
@@ -729,7 +734,7 @@ class NodeEditor(QFrame):
             width = max(self.fontwt, self.tm.lines[line1].width*self.fontwt)
             paint.fillRect(QRectF(x1, 3 + y1 * self.fontht, width - x1, self.fontht), QColor(0,0,255,100))
             y = y1 + self.tm.lines[line1].height
-            for i in range(line1+1, line2):
+            for i in range(int(line1+1), int(line2)):
                 width = self.tm.lines[i].width*self.fontwt
                 if width == 0:
                     width = self.fontwt
@@ -800,7 +805,7 @@ class NodeEditor(QFrame):
             y += l.height * self.fontht
         x = self.tm.cursor.get_x() * self.fontwt
         y = y - self.getScrollArea().verticalScrollBar().value() * self.fontht
-        return (x,y)
+        return (int(x),int(y))
 
     def coordinate_to_cursor(self, x, y):
         mouse_y = y / self.fontht

--- a/lib/eco/overlay.py
+++ b/lib/eco/overlay.py
@@ -61,9 +61,9 @@ class Overlay(QWidget):
         for _ in range(1000):
             hue = rangen.random() + GOLDEN_RATIO
             hue %= 1
-            rgb = [col * 255 for col in hsv_to_rgb(hue, SATURATION, VALUE)]
+            rgb = [int(col * 255) for col in hsv_to_rgb(hue, SATURATION, VALUE)]
             self._random_colours.append(QColor(*rgb))
-            rgb = [col * 255 for col in hsv_to_rgb(hue, SATURATION / 2.0, VALUE)]
+            rgb = [int(col * 255) for col in hsv_to_rgb(hue, SATURATION / 2.0, VALUE)]
             self._random_colours_outdated.append(QColor(*rgb))
 
     @property


### PR DESCRIPTION
It appears the API of PyQt has changed a bit. It's now enforcing the correct types for function arguments. This PR fixes some of the more obvious places I could find to get Eco up and running again. Though there might be more. But at least this allows us to create/edit files in Eco again.